### PR TITLE
[FIX] show empty string if lastname is unset

### DIFF
--- a/l10n_nl_partner_name/model/res_partner.py
+++ b/l10n_nl_partner_name/model/res_partner.py
@@ -49,7 +49,7 @@ class ResPartner(models.Model):
                 'name_format',
                 "${firstname or initials or ''}"
                 "${(firstname or initials) and ' ' or ''}"
-                "${infix or ''}${infix and ' ' or ''}${lastname}"))
+                "${infix or ''}${infix and ' ' or ''}${lastname or ''}"))
         name = name_template.render(**{
             'firstname': firstname,
             'lastname': lastname,


### PR DESCRIPTION
without this, we get 'False' as default name on a form where none of the fields involved is shown
