### PR TITLE
[FIX] don't use private fields, use the API

### DIFF
--- a/l10n_nl_postcodeapi/models/res_partner.py
+++ b/l10n_nl_postcodeapi/models/res_partner.py
@@ -91,8 +91,8 @@ class ResPartner(orm.Model):
         if not pc_info or not pc_info._data:
             return {}
         return {'value': {
-                'street_name': pc_info._data['street'],
-                'city': pc_info._data['town'],
+                'street_name': pc_info.street,
+                'city': pc_info.town,
                 'state_id': self.get_province(cr, uid, pc_info._province),
                 }}
 

--- a/l10n_nl_postcodeapi/models/res_partner.py
+++ b/l10n_nl_postcodeapi/models/res_partner.py
@@ -93,7 +93,7 @@ class ResPartner(orm.Model):
         return {'value': {
                 'street_name': pc_info.street,
                 'city': pc_info.town,
-                'state_id': self.get_province(cr, uid, pc_info._province),
+                'state_id': self.get_province(cr, uid, pc_info.province),
                 }}
 
     def fields_view_get(


### PR DESCRIPTION
version 0.2 of the postcode api supports as well protocol version 1 as 2, and in version 2, the internal data structures are different. By sticking to what the API offers, the addons works in both cases.
