### PR TITLE
[FIX] Use right encoding when generating XML File

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -128,7 +128,7 @@ class XafAuditfileExport(models.Model):
             return
 
         self.auditfile = base64.b64encode(etree.tostring(
-            xmldoc, xml_declaration=True, encoding='utf8'))
+            xmldoc, xml_declaration=True, encoding='UTF-8'))
 
     @api.multi
     def get_odoo_version(self):


### PR DESCRIPTION
File should have UTF-8 as encoding, not utf8.

We had errors with reading the generated XAF file with the old encoding, solved it by changing the encoding to UTF-8. This is used in python too. 
