### PR TITLE
Fix for travis test_flake8

### DIFF
--- a/l10n_nl_postcodeapi/models/res_partner.py
+++ b/l10n_nl_postcodeapi/models/res_partner.py
@@ -67,9 +67,9 @@ class ResPartner(models.Model):
         keyword in Python
         """
         postal_code = self.zip and self.zip.replace(' ', '')
-        if (not (postal_code and self.street_number)
-            or (self.country_id
-                and self.country_id != self.env.ref('base.nl'))):
+        country = self.country_id
+        if (not (postal_code and self.street_number) or
+            (country and country != self.env.ref('base.nl'))):
             return {}
 
         provider_obj = self.get_provider_obj()

--- a/l10n_nl_postcodeapi/models/res_partner.py
+++ b/l10n_nl_postcodeapi/models/res_partner.py
@@ -68,8 +68,8 @@ class ResPartner(models.Model):
         """
         postal_code = self.zip and self.zip.replace(' ', '')
         country = self.country_id
-        if (not (postal_code and self.street_number) or
-            (country and country != self.env.ref('base.nl'))):
+        if not (postal_code and self.street_number) or \
+                country and country != self.env.ref('base.nl'):
             return {}
 
         provider_obj = self.get_provider_obj()

--- a/l10n_nl_postcodeapi/models/res_partner.py
+++ b/l10n_nl_postcodeapi/models/res_partner.py
@@ -68,8 +68,8 @@ class ResPartner(models.Model):
         """
         postal_code = self.zip and self.zip.replace(' ', '')
         if (not (postal_code and self.street_number)
-                or (self.country_id and
-                    self.country_id != self.env.ref('base.nl'))):
+            or (self.country_id
+                and self.country_id != self.env.ref('base.nl'))):
             return {}
 
         provider_obj = self.get_provider_obj()


### PR DESCRIPTION
This fix is to avoid the following test failure on Travis:

```
4.27s$ travis_run_tests
======== Testing test_flake8 ========
l10n_nl_postcodeapi/models/res_partner.py:71:17: W503 line break before binary operator
```
