### PR TITLE
[IMP] Use API 2, because old api is no longer supported

### DIFF
--- a/l10n_nl_postcodeapi/README.rst
+++ b/l10n_nl_postcodeapi/README.rst
@@ -27,6 +27,9 @@ Configuration
 Please enter the API key that you request from PostcodeAPI into the system
 parameter 'l10n_nl_postcodeapi.apikey'
 
+Module version 8.0.0.2.0 and higher use a version 2 API key from PostcodeAPI.
+The old version 1 API key is not compatible with the new API key.
+
 Provinces are autocompleted if a country state with the exact name is found in
 the system. A CSV file with the Dutch provinces is included in the data
 directory, but not loaded by default. You can import the file manually.

--- a/l10n_nl_postcodeapi/__openerp__.py
+++ b/l10n_nl_postcodeapi/__openerp__.py
@@ -22,7 +22,7 @@
 {
     'name': 'Integration with PostcodeApi.nu',
     'summary': 'Autocomplete Dutch addresses using PostcodeApi.nu',
-    'version': '8.0.0.1.0',
+    'version': '8.0.0.2.0',
     'author': 'Therp BV,Odoo Community Association (OCA)',
     'category': 'Localization',
     'website': 'https://github.com/OCA/l10n-netherlands',

--- a/l10n_nl_postcodeapi/models/res_partner.py
+++ b/l10n_nl_postcodeapi/models/res_partner.py
@@ -37,7 +37,7 @@ class ResPartner(models.Model):
         if not apikey or apikey == 'Your API key':
             return False
         from pyPostcode import Api
-        provider = Api(apikey)
+        provider = Api(apikey, (2, 0, 0))
         test = provider.getaddress('1053NJ', '334T')
         if not test or not test._data:
             raise exceptions.Warning(


### PR DESCRIPTION
Until pyPostcode is updated to v0.3 on the odoo server, it still uses the now defunct version 1 api as default.

Added a warning that the old and new api keys are not compatible.

See https://github.com/steffex/pyPostcode/issues/12 and https://github.com/steffex/pyPostcode/pull/10
