### PR TITLE
[IMP][8.0] Extract method in l10n_nl_xaf_auditfile_export

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -92,10 +92,10 @@ class XafAuditfileExport(models.Model):
     @api.multi
     def button_generate(self):
         self.date_generated = fields.Datetime.now(self)
-        xml = self.env.ref('l10n_nl_xaf_auditfile_export.auditfile_template')\
-            .render(values={
-                'self': self,
-            })
+        auditfile_template = self._get_auditfile_template()
+        xml = auditfile_template.render(values={
+            'self': self,
+        })
         # the following is dealing with the fact that qweb templates don't like
         # namespaces, but we need the correct namespaces for validation
         # we inject them at parse time in order not to traverse the document
@@ -129,6 +129,13 @@ class XafAuditfileExport(models.Model):
 
         self.auditfile = base64.b64encode(etree.tostring(
             xmldoc, xml_declaration=True, encoding='UTF-8'))
+
+    @api.multi
+    def _get_auditfile_template(self):
+        self.ensure_one()
+        return self.env.ref(
+            'l10n_nl_xaf_auditfile_export.auditfile_template'
+        )
 
     @api.multi
     def get_odoo_version(self):


### PR DESCRIPTION
This PR is meant to simplify the way we can extend the auditfile template of module `l10n_nl_xaf_auditfile_export`.

Let's say I want to create a separate module to extend the auditfile template and, based on a certain condition, apply that extended template. For example, think about fixing issue #71 by creating a customized module.

In such cases, it would be very useful to have a simple method that can be easily extended, in order to retrieve the custom template.
This PR is a proposal to extract method `def _get_auditfile_template()` from the existing `def button_generate()`.