### PR TITLE
[FIX][10.0] Auditfile: add RUB currency

### DIFF
--- a/l10n_nl_xaf_auditfile_export/data/XmlAuditfileFinancieel3.2.xsd
+++ b/l10n_nl_xaf_auditfile_export/data/XmlAuditfileFinancieel3.2.xsd
@@ -1005,6 +1005,7 @@
 			<xsd:enumeration value="PYG"/>
 			<xsd:enumeration value="QAR"/>
 			<xsd:enumeration value="ROL"/>
+			<xsd:enumeration value="RUB"/>
 			<xsd:enumeration value="RUR"/>
 			<xsd:enumeration value="RWF"/>
 			<xsd:enumeration value="SAR"/>


### PR DESCRIPTION
The actual XAF specs can handle the currency RUR (formerly Russian ruble) instead of RUB (Russian ruble).

Actually we get this:

```
 Element '{http://www.auditfiles.nl/XAF/3.2}curCode': 'RUB' is not a valid value of the atomic type '{http://www.auditfiles.nl/XAF/3.2}CurrencycodeIso4217
```

This PR is a proposal to add the RUB currency in the xsd file.

Il will create PRs for v8 and v9 as well.