### PR TITLE
[FIX][10.0] l10n_nl_xaf_auditfile_export: formatting widgets

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
+++ b/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
@@ -18,7 +18,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from odoo import models
+from odoo import api, models
 
 
 class IrQwebAuditfileStringWidget999(models.AbstractModel):
@@ -26,9 +26,12 @@ class IrQwebAuditfileStringWidget999(models.AbstractModel):
     _inherit = 'ir.qweb.field'
     _max_length = 999
 
-    def _format(self, inner, options, qwebcontext):
-        return self.pool['ir.qweb']\
-            .eval_str(inner, qwebcontext)[:self._max_length]
+    @api.model
+    def value_to_html(self, value, options):
+        value = value[:self._max_length] if value else ''
+        return super(IrQwebAuditfileStringWidget999, self).value_to_html(
+            value, options
+        )
 
 
 class IrQwebAuditfileStringWidget9(models.AbstractModel):


### PR DESCRIPTION
Following the discussion on https://github.com/OCA/l10n-netherlands/pull/75 I realized that, after the migration to V10, the widgets in `l10n_nl_xaf_auditfile_export` are not formatted as expected. The method `_format()` was never called, this because it was removed from Odoo V10.

With this PR, the formatting is done by making use of another method: `value_to_html()`.
The widgets formatting seems working now.
