### PR TITLE
[FIX][10.0] Missing multicompany security rule

### DIFF
--- a/l10n_nl_tax_statement/__manifest__.py
+++ b/l10n_nl_tax_statement/__manifest__.py
@@ -15,6 +15,7 @@
     ],
     'data': [
         'security/ir.model.access.csv',
+        'security/tax_statement_security_rule.xml',
         'data/report_layouts.xml',
         'views/l10n_nl_vat_statement.xml',
         'report/reports.xml',

--- a/l10n_nl_tax_statement/security/tax_statement_security_rule.xml
+++ b/l10n_nl_tax_statement/security/tax_statement_security_rule.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="tax_statement_security_rule" model="ir.rule">
+        <field name="name">NL Tax Statement multicompany</field>
+        <field name="model_id" ref="model_l10n_nl_vat_statement"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
In module `l10n_nl_tax_statement` the multicompany security rule was missing.