### PR TITLE
[FIX][9.0] l10n_nl_xaf_auditfile_export: fix widgets

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
+++ b/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
@@ -22,8 +22,8 @@ from openerp import models
 
 
 class IrQwebAuditfileStringWidget999(models.AbstractModel):
-    _name = 'ir.qweb.field.auditfile.string999'
-    _inherit = 'ir.qweb.field'
+    _name = 'ir.qweb.widget.auditfile.string999'
+    _inherit = 'ir.qweb.widget'
     _max_length = 999
 
     def _format(self, inner, options, qwebcontext):
@@ -32,36 +32,36 @@ class IrQwebAuditfileStringWidget999(models.AbstractModel):
 
 
 class IrQwebAuditfileStringWidget9(models.AbstractModel):
-    _name = 'ir.qweb.field.auditfile.string9'
-    _inherit = 'ir.qweb.field.auditfile.string999'
+    _name = 'ir.qweb.widget.auditfile.string9'
+    _inherit = 'ir.qweb.widget.auditfile.string999'
     _max_length = 9
 
 
 class IrQwebAuditfileStringWidget10(models.AbstractModel):
-    _name = 'ir.qweb.field.auditfile.string10'
-    _inherit = 'ir.qweb.field.auditfile.string999'
+    _name = 'ir.qweb.widget.auditfile.string10'
+    _inherit = 'ir.qweb.widget.auditfile.string999'
     _max_length = 10
 
 
 class IrQwebAuditfileStringWidget15(models.AbstractModel):
-    _name = 'ir.qweb.field.auditfile.string15'
-    _inherit = 'ir.qweb.field.auditfile.string999'
+    _name = 'ir.qweb.widget.auditfile.string15'
+    _inherit = 'ir.qweb.widget.auditfile.string999'
     _max_length = 15
 
 
 class IrQwebAuditfileStringWidget20(models.AbstractModel):
-    _name = 'ir.qweb.field.auditfile.string20'
-    _inherit = 'ir.qweb.field.auditfile.string999'
+    _name = 'ir.qweb.widget.auditfile.string20'
+    _inherit = 'ir.qweb.widget.auditfile.string999'
     _max_length = 20
 
 
 class IrQwebAuditfileStringWidget30(models.AbstractModel):
-    _name = 'ir.qweb.field.auditfile.string30'
-    _inherit = 'ir.qweb.field.auditfile.string999'
+    _name = 'ir.qweb.widget.auditfile.string30'
+    _inherit = 'ir.qweb.widget.auditfile.string999'
     _max_length = 30
 
 
 class IrQwebAuditfileStringWidget50(models.AbstractModel):
-    _name = 'ir.qweb.field.auditfile.string50'
-    _inherit = 'ir.qweb.field.auditfile.string999'
+    _name = 'ir.qweb.widget.auditfile.string50'
+    _inherit = 'ir.qweb.widget.auditfile.string999'
     _max_length = 50


### PR DESCRIPTION
This PR fixes the widgets in `l10n_nl_xaf_auditfile_export`, the regression was introduced while porting the module to 9.0.