### PR TITLE
[FIX][9.0] l10n_nl_tax_statement: missing multicompany security rule

### DIFF
--- a/l10n_nl_tax_statement/__openerp__.py
+++ b/l10n_nl_tax_statement/__openerp__.py
@@ -15,6 +15,7 @@
     ],
     'data': [
         'security/ir.model.access.csv',
+        'security/tax_statement_security_rule.xml',
         'data/report_layouts.xml',
         'views/l10n_nl_vat_statement.xml',
         'report/reports.xml',

--- a/l10n_nl_tax_statement/security/tax_statement_security_rule.xml
+++ b/l10n_nl_tax_statement/security/tax_statement_security_rule.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="tax_statement_security_rule" model="ir.rule">
+        <field name="name">NL Tax Statement multicompany</field>
+        <field name="model_id" ref="model_l10n_nl_vat_statement"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This is the backport of https://github.com/OCA/l10n-netherlands/pull/93 to V9