### PR TITLE
[FIX] don't cap utf8 strings, add test data for that

### DIFF
--- a/l10n_nl_xaf_auditfile_export/__openerp__.py
+++ b/l10n_nl_xaf_auditfile_export/__openerp__.py
@@ -30,6 +30,7 @@
         'account',
     ],
     "data": [
+        "demo/res_partner.xml",
         "views/xaf_auditfile_export.xml",
         "views/menu.xml",
         'views/templates.xml',

--- a/l10n_nl_xaf_auditfile_export/demo/res_partner.xml
+++ b/l10n_nl_xaf_auditfile_export/demo/res_partner.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="demo_partner" model="res.partner">
+            <field name="name">Demo partner with special character in zip at cutoff position</field>
+            <field name="zip">123456789Ω</field>
+        </record>
+        <record id="base.main_partner" model="res.partner">
+            <!-- it's not important this this is NL, but it must be something /-->
+            <field name="country_id" ref="base.nl" />
+        </record>
+    </data>
+</openerp>

--- a/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
+++ b/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
@@ -26,10 +26,20 @@ class IrQwebAuditfileStringWidget999(models.AbstractModel):
     _inherit = 'ir.qweb.widget'
     _max_length = 999
 
+    def _trunk_eval(self, expr, qwebcontext):
+        if expr == "0":
+            return qwebcontext.get(0, '')
+        val = self.pool['ir.qweb'].eval(expr, qwebcontext)
+        if isinstance(val, basestring):
+            val = val[:self._max_length]
+        if isinstance(val, unicode):
+            return val.encode("utf8")
+        if val is False or val is None:
+            return ''
+        return str(val)
+
     def _format(self, inner, options, qwebcontext):
-        return tools.ustr(
-            self.pool['ir.qweb'].eval_str(inner, qwebcontext)
-        )[:self._max_length].encode('utf8')
+        return self._trunk_eval(inner, qwebcontext)
 
 
 class IrQwebAuditfileStringWidget9(models.AbstractModel):

--- a/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
+++ b/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
@@ -27,8 +27,9 @@ class IrQwebAuditfileStringWidget999(models.AbstractModel):
     _max_length = 999
 
     def _format(self, inner, options, qwebcontext):
-        return self.pool['ir.qweb']\
-            .eval_str(inner, qwebcontext)[:self._max_length]
+        return tools.ustr(
+            self.pool['ir.qweb'].eval_str(inner, qwebcontext)
+        )[:self._max_length].encode('utf8')
 
 
 class IrQwebAuditfileStringWidget9(models.AbstractModel):

--- a/l10n_nl_xaf_auditfile_export/tests/__init__.py
+++ b/l10n_nl_xaf_auditfile_export/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import test_l10n_nl_xaf_auditfile_export

--- a/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp.tests.common import TransactionCase
+
+
+class TestL10nNlXafAuditfileExport(TransactionCase):
+    def test_l10n_nl_xaf_auditfile_export(self):
+        export = self.env['xaf.auditfile.export'].create({})
+        export.button_generate()
+        self.assertTrue(export.auditfile)


### PR DESCRIPTION
for shortening strings exceeding the limits given in the schema, we can't slice the utf8 version, as this then only looks at bytes. If a multi byte unicode character happens to be the last one, it will be cut in the middle, yielding invalid utf8 and thus a broken audit file. Try the test data without the patch to see the effect.

@astirpe I bet you'll want to cherry pick this to 9 and 10