### PR TITLE
[IMP][10.0] l10n_nl_tax_statement: add lines 5d, 5e, 5f and 5g in report

### DIFF
--- a/l10n_nl_tax_statement/README.rst
+++ b/l10n_nl_tax_statement/README.rst
@@ -32,6 +32,7 @@ Usage
 #. Go to the menu: Invoicing -> Reports > Taxes Balance > NL BTW Statement
 #. Create a statement, providing a name and specifying start date and end date
 #. Press the Update button to calculate the report: the report lines will be displayed in the tab Statement
+#. Manually enter the BTW amounts of lines '5d', '5e', '5f' (in Edit mode, click on the amount of the line to be able to change it)
 #. Press the Post button to set the status of the statement to Posted; the statements set to this state cannot be modified anymore
 #. If you need to recalculate or modify or delete a statement already set to Posted status you need first to set it back to Draft status: press the button Reset to Draft
 #. If you need to print the report in PDF, open a statement form and click: Print -> NL Tax Statement

--- a/l10n_nl_tax_statement/__manifest__.py
+++ b/l10n_nl_tax_statement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Netherlands BTW Statement',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.1.0',
     'category': 'Localization',
     'license': 'AGPL-3',
     'author': 'Onestein, Odoo Community Association (OCA)',

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from odoo import api, fields, models, _
 from odoo.exceptions import Warning as UserError
+from odoo.tools.misc import formatLang
 
 
 class VatStatement(models.Model):
@@ -56,6 +57,21 @@ class VatStatement(models.Model):
     )
     date_posted = fields.Datetime(readonly=True)
     date_update = fields.Datetime(readonly=True)
+
+    btw_total = fields.Monetary(
+        compute='_compute_btw_total',
+        string='5g. Total (5c + 5d)'
+    )
+    format_btw_total = fields.Char(
+        compute='_amount_format_btw_total', string='5g - Total'
+    )
+
+    @api.multi
+    @api.depends('btw_total')
+    def _amount_format_btw_total(self):
+        for statement in self:
+            btw = formatLang(self.env, statement.btw_total, monetary=True)
+            statement.format_btw_total = btw
 
     @api.model
     def default_get(self, fields_list):
@@ -149,6 +165,15 @@ class VatStatement(models.Model):
         lines['5c'] = {
             'code': '5c', 'btw': 0.0,
             'name': _('Subtotaal (rubriek 5a min 5b)')}
+        lines['5d'] = {
+            'code': '5d', 'btw': 0.0,
+            'name': _('Vermindering volgens de kleineondernemersregeling')}
+        lines['5e'] = {
+            'code': '5e', 'btw': 0.0,
+            'name': _('Schatting vorige aangifte(n)')}
+        lines['5f'] = {
+            'code': '5f', 'btw': 0.0,
+            'name': _('Schatting deze aangifte')}
         return lines
 
     @api.model
@@ -288,3 +313,12 @@ class VatStatement(models.Model):
                     _('You cannot delete a posted statement! '
                       'Reset the statement to draft first.'))
         super(VatStatement, self).unlink()
+
+    @api.depends('line_ids.btw')
+    def _compute_btw_total(self):
+        for statement in self:
+            total = 0.0
+            for line in statement.line_ids:
+                if line.code in ['5c', '5d']:
+                    total += line.btw
+            statement.btw_total = total

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
@@ -63,12 +63,12 @@ class VatStatement(models.Model):
         string='5g. Total (5c + 5d)'
     )
     format_btw_total = fields.Char(
-        compute='_amount_format_btw_total', string='5g - Total'
+        compute='_compute_amount_format_btw_total', string='5g - Total'
     )
 
     @api.multi
     @api.depends('btw_total')
-    def _amount_format_btw_total(self):
+    def _compute_amount_format_btw_total(self):
         for statement in self:
             btw = formatLang(self.env, statement.btw_total, monetary=True)
             statement.format_btw_total = btw

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement_line.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement_line.py
@@ -49,8 +49,8 @@ class VatStatementLine(models.Model):
     )
     omzet = fields.Monetary()
     btw = fields.Monetary()
-    format_omzet = fields.Char(compute='_compute_amount_format', string='Omzet')
-    format_btw = fields.Char(compute='_compute_amount_format', string='BTW')
+    format_omzet = fields.Char(compute='_compute_amount_format')
+    format_btw = fields.Char(compute='_compute_amount_format')
 
     is_group = fields.Boolean(compute='_compute_is_group')
     is_readonly = fields.Boolean(compute='_compute_is_readonly')

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement_line.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement_line.py
@@ -18,7 +18,7 @@ BTW_DISPLAY = (
     '1a', '1b', '1c', '1d',
     '2a',
     '4a', '4b',
-    '5a', '5b', '5c','5d', '5e', '5f'
+    '5a', '5b', '5c', '5d', '5e', '5f'
 )
 
 GROUP_DISPLAY = (
@@ -49,8 +49,8 @@ class VatStatementLine(models.Model):
     )
     omzet = fields.Monetary()
     btw = fields.Monetary()
-    format_omzet = fields.Char(compute='_amount_format', string='Omzet')
-    format_btw = fields.Char(compute='_amount_format', string='BTW')
+    format_omzet = fields.Char(compute='_compute_amount_format', string='Omzet')
+    format_btw = fields.Char(compute='_compute_amount_format', string='BTW')
 
     is_group = fields.Boolean(compute='_compute_is_group')
     is_readonly = fields.Boolean(compute='_compute_is_readonly')
@@ -59,7 +59,7 @@ class VatStatementLine(models.Model):
 
     @api.multi
     @api.depends('omzet', 'btw', 'code')
-    def _amount_format(self):
+    def _compute_amount_format(self):
         for line in self:
             omzet = formatLang(self.env, line.omzet, monetary=True)
             btw = formatLang(self.env, line.btw, monetary=True)

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement_line.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement_line.py
@@ -8,15 +8,25 @@ from odoo.exceptions import Warning as UserError
 
 
 OMZET_DISPLAY = (
-    '1a', '1b', '1c', '1d', '1e', '2a', '3a', '3b', '3c', '4a', '4b'
+    '1a', '1b', '1c', '1d', '1e',
+    '2a',
+    '3a', '3b', '3c',
+    '4a', '4b'
 )
 
 BTW_DISPLAY = (
-    '1a', '1b', '1c', '1d', '2a', '4a', '4b', '5a', '5b', '5c'
+    '1a', '1b', '1c', '1d',
+    '2a',
+    '4a', '4b',
+    '5a', '5b', '5c','5d', '5e', '5f'
 )
 
 GROUP_DISPLAY = (
     '1', '2', '3', '4', '5'
+)
+
+EDITABLE_DISPLAY = (
+    '5d', '5e', '5f'
 )
 
 
@@ -43,6 +53,9 @@ class VatStatementLine(models.Model):
     format_btw = fields.Char(compute='_amount_format', string='BTW')
 
     is_group = fields.Boolean(compute='_compute_is_group')
+    is_readonly = fields.Boolean(compute='_compute_is_readonly')
+
+    state = fields.Selection(related='statement_id.state')
 
     @api.multi
     @api.depends('omzet', 'btw', 'code')
@@ -60,6 +73,15 @@ class VatStatementLine(models.Model):
     def _compute_is_group(self):
         for line in self:
             line.is_group = line.code in GROUP_DISPLAY
+
+    @api.multi
+    @api.depends('code')
+    def _compute_is_readonly(self):
+        for line in self:
+            if line.state == 'draft':
+                line.is_readonly = line.code not in EDITABLE_DISPLAY
+            else:
+                line.is_readonly = True
 
     @api.multi
     def unlink(self):

--- a/l10n_nl_tax_statement/report/report_tax_statement.xml
+++ b/l10n_nl_tax_statement/report/report_tax_statement.xml
@@ -69,6 +69,12 @@
                                     <div class="act_as_cell right"><span t-field="line.format_btw"/></div>
                                 </div>
                             </t>
+                            <div class="act_as_row lines">
+                                <!--## total btw-->
+                                <div class="act_as_cell left" style="width: 900px;"> &amp;nbsp; &amp;nbsp; 5g - Totaal</div>
+                                <div class="act_as_cell right"> </div>
+                                <div class="act_as_cell right"><span t-field="o.format_btw_total"/></div>
+                            </div>
                         </div>
                     </div>
                 </t>

--- a/l10n_nl_tax_statement/tests/test_l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/tests/test_l10n_nl_vat_statement.py
@@ -154,7 +154,7 @@ class TestVatStatement(TransactionCase):
         self.invoice_1._onchange_invoice_line_ids()
         self.invoice_1.action_invoice_open()
         self.statement_1.statement_update()
-        self.assertEqual(len(self.statement_1.line_ids.ids), 19)
+        self.assertEqual(len(self.statement_1.line_ids.ids), 22)
 
         _1 = self.StatLine.search(
             [('code', '=', '1'), ('id', 'in', self.statement_1.line_ids.ids)],

--- a/l10n_nl_tax_statement/views/l10n_nl_vat_statement.xml
+++ b/l10n_nl_tax_statement/views/l10n_nl_vat_statement.xml
@@ -34,7 +34,7 @@
                     </group>
                     <notebook name="notebook">
                         <page name="statement" string="Statement">
-                            <field name="line_ids" readonly="1">
+                            <field name="line_ids">
                                 <form>
                                     <group>
                                         <group>
@@ -47,16 +47,25 @@
                                         </group>
                                     </group>
                                 </form>
-                                <tree colors="grey:is_group">
+                                <tree colors="grey:is_group" editable="bottom" create="false" delete="false">
                                     <field name="is_group" invisible="1"/>
-                                    <field name="code"/>
-                                    <field name="name"/>
+                                    <field name="is_readonly" invisible="1"/>
+                                    <field name="code" readonly="1"/>
+                                    <field name="name" readonly="1"/>
                                     <field name="format_omzet" invisible="1"/>
                                     <field name="format_btw" invisible="1"/>
-                                    <field name="omzet" attrs="{'invisible': [('format_omzet', '=', False)]}"/>
-                                    <field name="btw" attrs="{'invisible': [('format_btw', '=', False)]}"/>
+                                    <field name="omzet" attrs="{'invisible': [('format_omzet', '=', False)],'readonly': [('is_readonly', '=', True)]}"/>
+                                    <field name="btw" attrs="{'invisible': [('format_btw', '=', False)],'readonly': [('is_readonly', '=', True)]}"/>
                                 </tree>
                             </field>
+                            <group>
+                                <group>
+                                </group>
+                                <group>
+                                    <label for="btw_total"/>
+                                    <field name="btw_total" nolabel="1"/>
+                                </group>
+                            </group>
                         </page>
                     </notebook>
                 </sheet>
@@ -71,6 +80,7 @@
                 <field name="name"/>
                 <field name="from_date"/>
                 <field name="to_date"/>
+                <field name="btw_total"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>


### PR DESCRIPTION
This PR is a proposal to improve the `NL VAT statement` by adding lines 5d, 5e, 5f, 5g.

Since the new lines '5d', '5e', '5f' can be manually set, such lines are made editable. All the other lines still remain read-only. Line 5g (Total: 5c + 5d) is also added.