### PR TITLE
[FIX][8.0] l10n_nl_xaf_auditfile_export: export periodNumber

### DIFF
--- a/l10n_nl_xaf_auditfile_export/views/templates.xml
+++ b/l10n_nl_xaf_auditfile_export/views/templates.xml
@@ -114,7 +114,7 @@
         </vatCodes>
         <periods>
             <period t-foreach="self.get_periods()" t-as="p">
-                <periodNumber><t t-esc="p.id" /></periodNumber>
+                <periodNumber><t t-esc="p.code[-1:] + p.code[0:2]" /></periodNumber>
                 <periodDesc><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}' /></periodDesc>
                 <startDatePeriod><t t-esc="p.date_start" /></startDatePeriod>
                 <endDatePeriod><t t-esc="p.date_stop" /></endDatePeriod>
@@ -135,7 +135,7 @@
                 <transaction t-foreach="self.get_moves(j)" t-as="m">
                     <nr><t t-esc="m.id" /></nr>
                     <desc><t t-esc="m.name" /></desc>
-                    <periodNumber><t t-esc="m.period_id.id" /></periodNumber>
+                    <periodNumber><t t-esc="m.period_id.code[-1:] + m.period_id.code[0:2]" /></periodNumber>
                     <trDt><t t-esc="m.date" /></trDt>
                     <amnt><t t-esc="m.amount" /></amnt>
                     <!-- left to inheriting modules


### PR DESCRIPTION
On an old multi-company database with a lot of companies we ran into this:
```
:21714:0:ERROR:SCHEMASV:SCHEMAV_CVC_TOTALDIGITS_VALID: Element '{http://www.auditfiles.nl/XAF/3.2}periodNumber': [facet 'totalDigits'] The value '3167' has more digits than are allowed ('3'). :21714:0:ERROR:SCHEMASV:SCHEMAV_CVC_DATATYPE_VALID_1_2_1: Element '{http://www.auditfiles.nl/XAF/3.2}periodNumber': '3167' is not a valid value of the atomic type '{http://www.auditfiles.nl/XAF/3.2}Nonnegativeinteger3'. :21719:0:ERROR:SCHEMASV:SCHEMAV_CVC_TOTALDIGITS_VALID: Element 

```
The issue is that the ID of `account_period` (for periodNumber) has more that three digits. This is not allowed as per the XAF Auditfile schema.

As I already proposed for version 10.0 (see https://github.com/OCA/l10n-netherlands/pull/59#issuecomment-282017404), I'm proposing to export the period numbers (`periodNumber`) using 3 digits: 1st digit is the last digit of the fiscal year, the other 2 digits are the month (Eg.: period "August 2017" is represented by number 708).

So this is the backport to 8.0 of the periodNumber representation already made for 10.0.