### PR TITLE
fix xaf auditfile

### DIFF
--- a/l10n_nl_xaf_auditfile_export/__openerp__.py
+++ b/l10n_nl_xaf_auditfile_export/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     "name": "XAF auditfile export",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.0.1",
     "author": "Therp BV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Accounting & Finance",

--- a/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
+++ b/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
@@ -26,9 +26,20 @@ class IrQwebAuditfileStringWidget999(models.AbstractModel):
     _inherit = 'ir.qweb.widget'
     _max_length = 999
 
+    def _trunk_eval(self, expr, qwebcontext):
+        if expr == "0":
+            return qwebcontext.get(0, '')
+        val = self.pool['ir.qweb'].eval(expr, qwebcontext)
+        if isinstance(val, basestring):
+            val = val[:self._max_length]
+        if isinstance(val, unicode):
+            return val.encode("utf8")
+        if val is False or val is None:
+            return ''
+        return str(val)
+
     def _format(self, inner, options, qwebcontext):
-        return self.pool['ir.qweb']\
-            .eval_str(inner, qwebcontext)[:self._max_length]
+        return self._trunk_eval(inner, qwebcontext)
 
 
 class IrQwebAuditfileStringWidget9(models.AbstractModel):


### PR DESCRIPTION
The xsd trunc should take place before the utf-8 conversion..
If not, the string truncate may end up with a partial special character resulting in a dump in the lxml iterparse function (e.g. char \xc3\x81 truncated into \xc3 which is an incorrect utf-8 char).
