### PR TITLE
[8.0] fix xaf auditfile contents

### DIFF
--- a/l10n_nl_xaf_auditfile_export/README.rst
+++ b/l10n_nl_xaf_auditfile_export/README.rst
@@ -46,6 +46,7 @@ Contributors
 ------------
 
 * Holger Brunn <hbrunn@therp.nl>
+* Luc De Meyer <info@noviat.com>
 
 Icon
 ----

--- a/l10n_nl_xaf_auditfile_export/__openerp__.py
+++ b/l10n_nl_xaf_auditfile_export/__openerp__.py
@@ -17,8 +17,8 @@
         "demo/res_partner.xml",
         "views/xaf_auditfile_export.xml",
         "views/menu.xml",
-        'views/xaf_template_default.xml',
         'views/xaf_template_all.xml',
+        'views/xaf_template_default.xml',
         'security/ir.model.access.csv',
     ],
     "qweb": [

--- a/l10n_nl_xaf_auditfile_export/__openerp__.py
+++ b/l10n_nl_xaf_auditfile_export/__openerp__.py
@@ -1,26 +1,10 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright (C) 2015 Therp BV <http://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 {
     "name": "XAF auditfile export",
-    "version": "8.0.1.0.0",
+    "version": "8.0.2.0.0",
     "author": "Therp BV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Accounting & Finance",
@@ -33,7 +17,8 @@
         "demo/res_partner.xml",
         "views/xaf_auditfile_export.xml",
         "views/menu.xml",
-        'views/templates.xml',
+        'views/xaf_template_default.xml',
+        'views/xaf_template_all.xml',
         'security/ir.model.access.csv',
     ],
     "qweb": [

--- a/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
+++ b/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Therp BV (<http://therp.nl>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright (C) 2015 Therp BV <http://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from openerp import models
 
 

--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -150,7 +150,7 @@ class XafAuditfileExport(models.Model):
             "WHERE period_id IN %s AND account_id NOT IN %s "
             "AND company_id=%s ",
             (tuple(self._periods._ids),
-             tuple(self.exclude_account_ids._ids),
+             tuple(self.exclude_account_ids._ids or [0]),
              self.company_id.id))
         res = self._cr.fetchall()
 

--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -90,9 +90,13 @@ class XafAuditfileExport(models.Model):
     @api.multi
     def button_generate(self):
         self.date_generated = fields.Datetime.now(self)
-        self._get_data()
+        accounts, journals, partner_ids, periods = self._get_data()
         auditfile_template = self._get_auditfile_template()
         xml = auditfile_template.render(values={
+            'accounts': accounts,
+            'journals': journals,
+            'partner_ids': partner_ids,
+            'periods': periods,
             'self': self,
         })
         # the following is dealing with the fact that qweb templates don't like
@@ -138,7 +142,7 @@ class XafAuditfileExport(models.Model):
         )
 
     def _get_data(self):
-        self._periods = self.env['account.period'].search([
+        periods = self.env['account.period'].search([
             ('date_start', '<=', self.period_end.date_stop),
             ('date_stop', '>=', self.period_start.date_start),
             ('company_id', '=', self.company_id.id),
@@ -149,20 +153,22 @@ class XafAuditfileExport(models.Model):
             "FROM account_move_line "
             "WHERE period_id IN %s AND account_id NOT IN %s "
             "AND company_id=%s ",
-            (tuple(self._periods._ids),
+            (tuple(periods._ids),
              tuple(self.exclude_account_ids._ids or [0]),
              self.company_id.id))
         res = self._cr.fetchall()
 
-        self._partner_ids = list(set([x[0] for x in res]))
+        partner_ids = list(set([x[0] for x in res]))
 
         account_ids = list(set([x[1] for x in res]))
-        self._accounts = self.env['account.account'].search([
+        accounts = self.env['account.account'].search([
             ('id', 'in', account_ids)], order='code')
 
         journal_ids = list(set([x[2] for x in res]))
-        self._journals = self.env['account.journal'].search([
+        journals = self.env['account.journal'].search([
             ('id', 'in', journal_ids)], order='code')
+
+        return accounts, journals, partner_ids, periods
 
     @api.multi
     def get_odoo_version(self):
@@ -170,12 +176,12 @@ class XafAuditfileExport(models.Model):
         return release.version
 
     @api.multi
-    def get_partners(self):
+    def get_partners(self, partner_ids):
         '''return a generator over partners'''
         offset = 0
         while True:
             results = self.env['res.partner'].search(
-                [('id', 'in', self._partner_ids)],
+                [('id', 'in', partner_ids)],
                 offset=offset, order='display_name',
                 limit=self.env['ir.config_parameter'].get_param(
                     'l10n_nl_xaf_auditfile_export.max_records',
@@ -189,64 +195,49 @@ class XafAuditfileExport(models.Model):
             del results
 
     @api.multi
-    def get_accounts(self):
-        '''return browse record list of accounts'''
-        return self._accounts
-
-    @api.multi
-    def get_periods(self):
-        '''return periods in this export'''
-        return self._periods
-
-    @api.multi
-    def get_move_line_count(self):
+    def get_move_line_count(self, periods):
         '''return amount of move lines'''
         self.env.cr.execute(
             'select count(id) from account_move_line where period_id in %s '
             'and (company_id=%s or company_id is null) '
             'and account_id not in %s',
-            (tuple(p.id for p in self.get_periods()),
+            (tuple(p.id for p in periods),
                 self.company_id.id,
                 tuple(self.exclude_account_ids.ids) or (0, )))
         return self.env.cr.fetchall()[0][0] or 0
 
     @api.multi
-    def get_move_line_total_debit(self):
+    def get_move_line_total_debit(self, periods):
         '''return total debit of move lines'''
         self.env.cr.execute(
             'select sum(debit) from account_move_line where period_id in %s '
             'and (company_id=%s or company_id is null) '
             'and account_id not in %s',
-            (tuple(p.id for p in self.get_periods()),
+            (tuple(p.id for p in periods),
                 self.company_id.id,
                 tuple(self.exclude_account_ids.ids) or (0, )))
         return self.env.cr.fetchall()[0][0] or 0
 
     @api.multi
-    def get_move_line_total_credit(self):
+    def get_move_line_total_credit(self, periods):
         '''return total credit of move lines'''
         self.env.cr.execute(
             'select sum(credit) from account_move_line where period_id in %s '
             'and (company_id=%s or company_id is null) '
             'and account_id not in %s',
-            (tuple(p.id for p in self.get_periods()),
+            (tuple(p.id for p in periods),
                 self.company_id.id,
                 tuple(self.exclude_account_ids.ids) or (0, )))
         return self.env.cr.fetchall()[0][0] or 0
 
     @api.multi
-    def get_journals(self):
-        '''return journals'''
-        return self._journals
-
-    @api.multi
-    def get_moves(self, journal):
+    def get_moves(self, journal, periods):
         '''return moves for a journal, generator style'''
         offset = 0
         while True:
             results = self.env['account.move'].search(
                 [
-                    ('period_id', 'in', self._periods.ids),
+                    ('period_id', 'in', periods.ids),
                     ('journal_id', '=', journal.id),
                 ],
                 offset=offset,

--- a/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
@@ -1,11 +1,20 @@
 # -*- coding: utf-8 -*-
 # © 2017 Therp BV <http://therp.nl>
+# Copyright 2018 Noviat
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp.tests.common import TransactionCase
 
 
 class TestL10nNlXafAuditfileExport(TransactionCase):
-    def test_l10n_nl_xaf_auditfile_export(self):
+
+    def test_l10n_nl_xaf_auditfile_export_default(self):
         export = self.env['xaf.auditfile.export'].create({})
+        export.button_generate()
+        self.assertTrue(export.auditfile)
+
+    def test_l10n_nl_xaf_auditfile_export_all(self):
+        export = self.env['xaf.auditfile.export'].create(
+            {'data_export': 'all'})
         export.button_generate()
         self.assertTrue(export.auditfile)

--- a/l10n_nl_xaf_auditfile_export/views/xaf_auditfile_export.xml
+++ b/l10n_nl_xaf_auditfile_export/views/xaf_auditfile_export.xml
@@ -23,6 +23,7 @@
                             <field name="name" attrs="{'readonly': [('auditfile', '!=', False)]}" />
                             <field name="period_start" attrs="{'readonly': [('auditfile', '!=', False)]}" />
                             <field name="period_end" attrs="{'readonly': [('auditfile', '!=', False)]}" />
+                            <field name="data_export" attrs="{'readonly': [('auditfile', '!=', False)]}" />
                             <field name="exclude_account_ids" attrs="{'readonly': [('auditfile', '!=', False)]}" />
                             <field name="company_id" attrs="{'readonly': [('auditfile', '!=', False)]}" groups="base.group_multi_company" />
                         </group>

--- a/l10n_nl_xaf_auditfile_export/views/xaf_template_all.xml
+++ b/l10n_nl_xaf_auditfile_export/views/xaf_template_all.xml
@@ -31,7 +31,7 @@
              but that doesn't really seem worth the effort
         <postalAddress/> /-->
         <customersSuppliers>
-            <customerSupplier t-foreach="self.get_partners()" t-as="p">
+            <customerSupplier t-foreach="self.get_partners(partner_ids)" t-as="p">
                 <custSupID><t t-esc="p.id" /></custSupID>
                 <custSupName><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}' /></custSupName>
                 <contact t-if="p.is_company and p.child_ids"><t t-esc="p.child_ids[0].name" t-esc-options='{"widget": "auditfile.string50"}' /></contact>
@@ -73,7 +73,7 @@
             </customerSupplier>
         </customersSuppliers>
         <generalLedger>
-            <ledgerAccount t-foreach="self.get_accounts()" t-as="a">
+            <ledgerAccount t-foreach="accounts" t-as="a">
                 <accID><t t-esc="a.code" /></accID>
                 <accDesc><t t-esc="a.name" t-esc-options='{"widget": "auditfile.string999"}' /></accDesc>
                 <accTp><t t-esc="'P' if a.user_type.report_type in ['income', 'expense'] else 'B' if a.user_type.report_type in ['asset', 'liability'] else 'M'" /></accTp>
@@ -115,7 +115,7 @@
         </vatCodes>
         -->
         <periods>
-            <period t-foreach="self.get_periods()" t-as="p">
+            <period t-foreach="periods" t-as="p">
                 <periodNumber><t t-esc="p.date_stop[3] + p.date_stop[5:7]"/></periodNumber>
                 <periodDesc><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}' /></periodDesc>
                 <startDatePeriod><t t-esc="p.date_start" /></startDatePeriod>
@@ -123,10 +123,10 @@
             </period>
         </periods>
         <transactions>
-            <linesCount><t t-esc="self.get_move_line_count()" /></linesCount>
-            <totalDebit><t t-esc="self.get_move_line_total_debit()" /></totalDebit>
-            <totalCredit><t t-esc="self.get_move_line_total_credit()" /></totalCredit>
-            <journal t-foreach="self.get_journals()" t-as="j">
+            <linesCount><t t-esc="self.get_move_line_count(periods)" /></linesCount>
+            <totalDebit><t t-esc="self.get_move_line_total_debit(periods)" /></totalDebit>
+            <totalCredit><t t-esc="self.get_move_line_total_credit(periods)" /></totalCredit>
+            <journal t-foreach="journals" t-as="j">
                 <jrnID><t t-esc="j.code" /></jrnID>
                 <desc><t t-esc="j.name" /></desc>
                 <jrnTp><t t-esc="'B' if j.type == 'bank' else 'C' if j.type == 'cash' else 'O' if j.type == 'situation' else 'S' if j.type in ['sale', 'sale_refund'] else 'P' if j.type in ['purchase', 'purchase_refund'] else 'Z'" /></jrnTp>
@@ -134,7 +134,7 @@
                 <offsetAccID />
                 <bankAccNr />
                 /-->
-                <transaction t-foreach="self.get_moves(j)" t-as="m">
+                <transaction t-foreach="self.get_moves(j, periods)" t-as="m">
                     <nr><t t-esc="m.id" /></nr>
                     <desc><t t-esc="m.name" /></desc>
                     <periodNumber><t t-esc="m.period_id.date_stop[3] + m.period_id.date_stop[5:7]"/></periodNumber>

--- a/l10n_nl_xaf_auditfile_export/views/xaf_template_all.xml
+++ b/l10n_nl_xaf_auditfile_export/views/xaf_template_all.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
     <data>
-        <template id="auditfile_template">
+        <template id="xaf_template_all">
 <auditfile>
     <header>
         <fiscalYear><t t-esc="self.period_start.fiscalyear_id.name" t-esc-options='{"widget": "auditfile.string9"}' /></fiscalYear>
@@ -104,6 +104,7 @@
         <!-- we might fill in those later
         <openingBalance />
         /-->
+        <!-- future extensions
         <vatCodes>
             <vatCode t-foreach="self.get_taxes()" t-as="t">
                 <vatID><t t-esc="t.id" /></vatID>
@@ -112,6 +113,7 @@
                 <vatToClaimAccID><t t-esc="t.account_collected_id.code" /></vatToClaimAccID>
             </vatCode>
         </vatCodes>
+        -->
         <periods>
             <period t-foreach="self.get_periods()" t-as="p">
                 <periodNumber><t t-esc="p.date_stop[3] + p.date_stop[5:7]"/></periodNumber>

--- a/l10n_nl_xaf_auditfile_export/views/xaf_template_default.xml
+++ b/l10n_nl_xaf_auditfile_export/views/xaf_template_default.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+  <data>
+
+    <template id="xaf_template_default">
+      <auditfile>
+        <header>
+          <fiscalYear><t t-esc="self.period_start.fiscalyear_id.name" t-esc-options='{"widget": "auditfile.string9"}'/></fiscalYear>
+          <startDate><t t-esc="self.period_start.date_start"/></startDate>
+          <endDate><t t-esc="self.period_end.date_stop"/></endDate>
+          <curCode><t t-esc="self.company_id.currency_id.name"/></curCode>
+          <dateCreated><t t-esc="self.date_generated[:10]"/></dateCreated>
+          <softwareDesc>Odoo</softwareDesc>
+          <softwareVersion><t t-esc="self.get_odoo_version()" t-esc-options='{"widget": "auditfile.string20"}'/></softwareVersion>
+        </header>
+        <company>
+          <companyIdent><t t-esc="self.company_id.company_registry" t-esc-options='{"widget": "auditfile.string35"}'/></companyIdent>
+          <companyName><t t-esc="self.company_id.name" t-esc-options='{"widget": "auditfile.string999"}'/></companyName>
+          <taxRegistrationCountry><t t-esc="self.company_id.country_id.code"/></taxRegistrationCountry>
+          <taxRegIdent><t t-esc="self.company_id.vat" t-esc-options='{"widget": "auditfile.string30"}'/></taxRegIdent>
+          <streetAddress>
+            <streetname><t t-esc="self.company_id.street" t-esc-options='{"widget": "auditfile.string999"}'/></streetname>
+            <city><t t-esc="self.company_id.city" t-esc-options='{"widget": "auditfile.string50"}'/></city>
+            <postalCode><t t-esc="self.company_id.zip" t-esc-options='{"widget": "auditfile.string15"}'/></postalCode>
+            <region><t t-esc="self.company_id.state_id.name" t-esc-options='{"widget": "auditfile.string50"}'/></region>
+            <country t-if="self.company_id.country_id"><t t-esc="self.company_id.country_id.code"/></country>
+          </streetAddress>
+          <customersSuppliers>
+            <customerSupplier t-foreach="self.get_partners()" t-as="p">
+              <custSupID><t t-esc="p.id"/></custSupID>
+              <custSupName><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}'/></custSupName>
+              <taxRegistrationCountry t-if="p.country_id"><t t-esc="p.country_id.code"/></taxRegistrationCountry>
+              <taxRegIdent><t t-esc="p.vat" t-esc-options='{"widget": "auditfile.string30"}'/></taxRegIdent>
+              <streetAddress>
+                <streetname><t t-esc="p.street" t-esc-options='{"widget": "auditfile.string999"}'/></streetname>
+                <city><t t-esc="p.city" t-esc-options='{"widget": "auditfile.string50"}'/></city>
+                <postalCode><t t-esc="p.zip" t-esc-options='{"widget": "auditfile.string10"}'/></postalCode>
+                <region><t t-esc="p.state_id.name" t-esc-options='{"widget": "auditfile.string50"}'/></region>
+                <country t-if="p.country_id"><t t-esc="p.country_id.code"/></country>
+              </streetAddress>
+            </customerSupplier>
+          </customersSuppliers>
+          <generalLedger>
+            <ledgerAccount t-foreach="self.get_accounts()" t-as="a">
+              <accID><t t-esc="a.code"/></accID>
+              <accDesc><t t-esc="a.name" t-esc-options='{"widget": "auditfile.string999"}'/></accDesc>
+              <accTp><t t-esc="'P' if a.user_type.report_type in ['income', 'expense'] else 'B' if a.user_type.report_type in ['asset', 'liability'] else 'M'"/></accTp>
+            </ledgerAccount>
+          </generalLedger>
+          <!-- we might fill in those later
+        <openingBalance />
+        /-->
+          <periods>
+            <period t-foreach="self.get_periods()" t-as="p">
+              <periodNumber><t t-esc="p.id" /></periodNumber>
+              <periodDesc><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}'/></periodDesc>
+              <startDatePeriod><t t-esc="p.date_start"/></startDatePeriod>
+              <endDatePeriod><t t-esc="p.date_stop"/></endDatePeriod>
+            </period>
+          </periods>
+          <transactions>
+            <linesCount><t t-esc="self.get_move_line_count()"/></linesCount>
+            <totalDebit><t t-esc="self.get_move_line_total_debit()"/></totalDebit>
+            <totalCredit><t t-esc="self.get_move_line_total_credit()"/></totalCredit>
+            <journal t-foreach="self.get_journals()" t-as="j">
+              <jrnID><t t-esc="j.code"/></jrnID>
+              <desc><t t-esc="j.name"/></desc>
+              <jrnTp><t t-esc="'B' if j.type == 'bank' else 'C' if j.type == 'cash' else 'O' if j.type == 'situation' else 'S' if j.type in ['sale', 'sale_refund'] else 'P' if j.type in ['purchase', 'purchase_refund'] else 'Z'"/></jrnTp>
+              <transaction t-foreach="self.get_moves(j)" t-as="m">
+                <nr><t t-esc="m.id"/></nr>
+                <desc><t t-esc="m.name"/></desc>
+                <periodNumber><t t-esc="m.period_id.id"/></periodNumber>
+                <trDt><t t-esc="m.date"/></trDt>
+                <amnt><t t-esc="m.amount"/></amnt>
+                <trLine t-foreach="m.line_id" t-as="l">
+                  <nr><t t-esc="l.id"/></nr>
+                  <accID><t t-esc="l.account_id.code"/></accID>
+                  <docRef><t t-esc="l.ref" t-esc-options='{"widget": "auditfile.string999"}'/></docRef>
+                  <effDate><t t-esc="l.date"/></effDate>
+                  <desc><t t-esc="l.name"/></desc>
+                  <amnt><t t-esc="l.credit or l.debit"/></amnt>
+                  <amntTp><t t-esc="'C' if l.credit else 'D'"/></amntTp>
+                  <recRef t-if="l.reconcile_id"><t t-esc="l.reconcile_id.name" /></recRef>
+                  <custSupID t-if="l.partner_id"><t t-esc="l.partner_id.id" /></custSupID>
+                  <invRef t-if="l.invoice"><t t-esc="l.invoice.number" t-esc-options='{"widget": "auditfile.string999"}'/></invRef>
+                  <currency t-if="l.currency_id and l.amount_currency">
+                    <curCode><t t-esc="l.currency_id.name"/></curCode>
+                    <curAmnt><t t-esc="l.amount_currency"/></curAmnt>
+                  </currency>
+                </trLine>
+              </transaction>
+            </journal>
+          </transactions>
+        </company>
+      </auditfile>
+    </template>
+
+  </data>
+</openerp>

--- a/l10n_nl_xaf_auditfile_export/views/xaf_template_default.xml
+++ b/l10n_nl_xaf_auditfile_export/views/xaf_template_default.xml
@@ -1,99 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
   <data>
-
-    <template id="xaf_template_default">
-      <auditfile>
-        <header>
-          <fiscalYear><t t-esc="self.period_start.fiscalyear_id.name" t-esc-options='{"widget": "auditfile.string9"}'/></fiscalYear>
-          <startDate><t t-esc="self.period_start.date_start"/></startDate>
-          <endDate><t t-esc="self.period_end.date_stop"/></endDate>
-          <curCode><t t-esc="self.company_id.currency_id.name"/></curCode>
-          <dateCreated><t t-esc="self.date_generated[:10]"/></dateCreated>
-          <softwareDesc>Odoo</softwareDesc>
-          <softwareVersion><t t-esc="self.get_odoo_version()" t-esc-options='{"widget": "auditfile.string20"}'/></softwareVersion>
-        </header>
-        <company>
-          <companyIdent><t t-esc="self.company_id.company_registry" t-esc-options='{"widget": "auditfile.string35"}'/></companyIdent>
-          <companyName><t t-esc="self.company_id.name" t-esc-options='{"widget": "auditfile.string999"}'/></companyName>
-          <taxRegistrationCountry><t t-esc="self.company_id.country_id.code"/></taxRegistrationCountry>
-          <taxRegIdent><t t-esc="self.company_id.vat" t-esc-options='{"widget": "auditfile.string30"}'/></taxRegIdent>
-          <streetAddress>
-            <streetname><t t-esc="self.company_id.street" t-esc-options='{"widget": "auditfile.string999"}'/></streetname>
-            <city><t t-esc="self.company_id.city" t-esc-options='{"widget": "auditfile.string50"}'/></city>
-            <postalCode><t t-esc="self.company_id.zip" t-esc-options='{"widget": "auditfile.string15"}'/></postalCode>
-            <region><t t-esc="self.company_id.state_id.name" t-esc-options='{"widget": "auditfile.string50"}'/></region>
-            <country t-if="self.company_id.country_id"><t t-esc="self.company_id.country_id.code"/></country>
-          </streetAddress>
-          <customersSuppliers>
+      <template id="xaf_template_default">
+<auditfile>
+    <header>
+        <fiscalYear><t t-esc="self.period_start.fiscalyear_id.name" t-esc-options='{"widget": "auditfile.string9"}' /></fiscalYear>
+        <startDate><t t-esc="self.period_start.date_start" /></startDate>
+        <endDate><t t-esc="self.period_end.date_stop" /></endDate>
+        <curCode><t t-esc="self.company_id.currency_id.name" /></curCode>
+        <dateCreated><t t-esc="self.date_generated[:10]" /></dateCreated>
+        <softwareDesc>Odoo</softwareDesc>
+        <softwareVersion><t t-esc="self.get_odoo_version()" t-esc-options='{"widget": "auditfile.string20"}' /></softwareVersion>
+    </header>
+    <company>
+        <companyIdent><t t-esc="self.company_id.company_registry" t-esc-options='{"widget": "auditfile.string35"}' /></companyIdent>
+        <companyName><t t-esc="self.company_id.name" t-esc-options='{"widget": "auditfile.string999"}' /></companyName>
+        <taxRegistrationCountry><t t-esc="self.company_id.country_id.code" /></taxRegistrationCountry>
+        <taxRegIdent><t t-esc="self.company_id.vat" t-esc-options='{"widget": "auditfile.string30"}' /></taxRegIdent>
+        <streetAddress>
+            <streetname><t t-esc="self.company_id.street" t-esc-options='{"widget": "auditfile.string999"}' /></streetname>
+            <city><t t-esc="self.company_id.city" t-esc-options='{"widget": "auditfile.string50"}' /></city>
+            <postalCode><t t-esc="self.company_id.zip" t-esc-options='{"widget": "auditfile.string15"}' /></postalCode>
+            <region><t t-esc="self.company_id.state_id.name" t-esc-options='{"widget": "auditfile.string50"}' /></region>
+            <country t-if="self.company_id.country_id"><t t-esc="self.company_id.country_id.code" /></country>
+        </streetAddress>
+        <customersSuppliers>
             <customerSupplier t-foreach="self.get_partners(partner_ids)" t-as="p">
-              <custSupID><t t-esc="p.id"/></custSupID>
-              <custSupName><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}'/></custSupName>
-              <taxRegistrationCountry t-if="p.country_id"><t t-esc="p.country_id.code"/></taxRegistrationCountry>
-              <taxRegIdent><t t-esc="p.vat" t-esc-options='{"widget": "auditfile.string30"}'/></taxRegIdent>
-              <streetAddress>
-                <streetname><t t-esc="p.street" t-esc-options='{"widget": "auditfile.string999"}'/></streetname>
-                <city><t t-esc="p.city" t-esc-options='{"widget": "auditfile.string50"}'/></city>
-                <postalCode><t t-esc="p.zip" t-esc-options='{"widget": "auditfile.string10"}'/></postalCode>
-                <region><t t-esc="p.state_id.name" t-esc-options='{"widget": "auditfile.string50"}'/></region>
-                <country t-if="p.country_id"><t t-esc="p.country_id.code"/></country>
-              </streetAddress>
+                <custSupID><t t-esc="p.id" /></custSupID>
+                <custSupName><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}' /></custSupName>
+                <taxRegistrationCountry t-if="p.country_id"><t t-esc="p.country_id.code" /></taxRegistrationCountry>
+                <taxRegIdent><t t-esc="p.vat" t-esc-options='{"widget": "auditfile.string30"}' /></taxRegIdent>
+                <streetAddress>
+                    <streetname><t t-esc="p.street" t-esc-options='{"widget": "auditfile.string999"}' /></streetname>
+                    <city><t t-esc="p.city" t-esc-options='{"widget": "auditfile.string50"}' /></city>
+                    <postalCode><t t-esc="p.zip" t-esc-options='{"widget": "auditfile.string10"}' /></postalCode>
+                    <region><t t-esc="p.state_id.name" t-esc-options='{"widget": "auditfile.string50"}' /></region>
+                    <country t-if="p.country_id"><t t-esc="p.country_id.code" /></country>
+                </streetAddress>
             </customerSupplier>
-          </customersSuppliers>
-          <generalLedger>
+        </customersSuppliers>
+        <generalLedger>
             <ledgerAccount t-foreach="accounts" t-as="a">
-              <accID><t t-esc="a.code"/></accID>
-              <accDesc><t t-esc="a.name" t-esc-options='{"widget": "auditfile.string999"}'/></accDesc>
-              <accTp><t t-esc="'P' if a.user_type.report_type in ['income', 'expense'] else 'B' if a.user_type.report_type in ['asset', 'liability'] else 'M'"/></accTp>
+                <accID><t t-esc="a.code" /></accID>
+                <accDesc><t t-esc="a.name" t-esc-options='{"widget": "auditfile.string999"}' /></accDesc>
+                <accTp><t t-esc="'P' if a.user_type.report_type in ['income', 'expense'] else 'B' if a.user_type.report_type in ['asset', 'liability'] else 'M'" /></accTp>
             </ledgerAccount>
-          </generalLedger>
-          <!-- we might fill in those later
-        <openingBalance />
-        /-->
-          <periods>
+        </generalLedger>
+        <!-- we might fill in those later
+             <openingBalance />
+             /-->
+        <periods>
             <period t-foreach="periods" t-as="p">
-              <periodNumber><t t-esc="p.id" /></periodNumber>
-              <periodDesc><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}'/></periodDesc>
-              <startDatePeriod><t t-esc="p.date_start"/></startDatePeriod>
-              <endDatePeriod><t t-esc="p.date_stop"/></endDatePeriod>
+                <periodNumber><t t-esc="p.id" /></periodNumber>
+                <periodDesc><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}' /></periodDesc>
+                <startDatePeriod><t t-esc="p.date_start" /></startDatePeriod>
+                <endDatePeriod><t t-esc="p.date_stop" /></endDatePeriod>
             </period>
-          </periods>
-          <transactions>
-            <linesCount><t t-esc="self.get_move_line_count(periods)"/></linesCount>
-            <totalDebit><t t-esc="self.get_move_line_total_debit(periods)"/></totalDebit>
-            <totalCredit><t t-esc="self.get_move_line_total_credit(periods)"/></totalCredit>
+        </periods>
+        <transactions>
+            <linesCount><t t-esc="self.get_move_line_count(periods)" /></linesCount>
+            <totalDebit><t t-esc="self.get_move_line_total_debit(periods)" /></totalDebit>
+            <totalCredit><t t-esc="self.get_move_line_total_credit(periods)" /></totalCredit>
             <journal t-foreach="journals" t-as="j">
-              <jrnID><t t-esc="j.code"/></jrnID>
-              <desc><t t-esc="j.name"/></desc>
-              <jrnTp><t t-esc="'B' if j.type == 'bank' else 'C' if j.type == 'cash' else 'O' if j.type == 'situation' else 'S' if j.type in ['sale', 'sale_refund'] else 'P' if j.type in ['purchase', 'purchase_refund'] else 'Z'"/></jrnTp>
-              <transaction t-foreach="self.get_moves(j, periods)" t-as="m">
-                <nr><t t-esc="m.id"/></nr>
-                <desc><t t-esc="m.name"/></desc>
-                <periodNumber><t t-esc="m.period_id.id"/></periodNumber>
-                <trDt><t t-esc="m.date"/></trDt>
-                <amnt><t t-esc="m.amount"/></amnt>
-                <trLine t-foreach="m.line_id" t-as="l">
-                  <nr><t t-esc="l.id"/></nr>
-                  <accID><t t-esc="l.account_id.code"/></accID>
-                  <docRef><t t-esc="l.ref" t-esc-options='{"widget": "auditfile.string999"}'/></docRef>
-                  <effDate><t t-esc="l.date"/></effDate>
-                  <desc><t t-esc="l.name"/></desc>
-                  <amnt><t t-esc="l.credit or l.debit"/></amnt>
-                  <amntTp><t t-esc="'C' if l.credit else 'D'"/></amntTp>
-                  <recRef t-if="l.reconcile_id"><t t-esc="l.reconcile_id.name" /></recRef>
-                  <custSupID t-if="l.partner_id"><t t-esc="l.partner_id.id" /></custSupID>
-                  <invRef t-if="l.invoice"><t t-esc="l.invoice.number" t-esc-options='{"widget": "auditfile.string999"}'/></invRef>
-                  <currency t-if="l.currency_id and l.amount_currency">
-                    <curCode><t t-esc="l.currency_id.name"/></curCode>
-                    <curAmnt><t t-esc="l.amount_currency"/></curAmnt>
-                  </currency>
-                </trLine>
-              </transaction>
+                <jrnID><t t-esc="j.code" /></jrnID>
+                <desc><t t-esc="j.name" /></desc>
+                <jrnTp><t t-esc="'B' if j.type == 'bank' else 'C' if j.type == 'cash' else 'O' if j.type == 'situation' else 'S' if j.type in ['sale', 'sale_refund'] else 'P' if j.type in ['purchase', 'purchase_refund'] else 'Z'" /></jrnTp>
+                <transaction t-foreach="self.get_moves(j, periods)" t-as="m">
+                    <nr><t t-esc="m.id" /></nr>
+                    <desc><t t-esc="m.name" /></desc>
+                    <periodNumber><t t-esc="m.period_id.id" /></periodNumber>
+                    <trDt><t t-esc="m.date" /></trDt>
+                    <amnt><t t-esc="m.amount" /></amnt>
+                    <trLine t-foreach="m.line_id" t-as="l">
+                        <nr><t t-esc="l.id" /></nr>
+                        <accID><t t-esc="l.account_id.code" /></accID>
+                        <docRef><t t-esc="l.ref" t-esc-options='{"widget": "auditfile.string999"}' /></docRef>
+                        <effDate><t t-esc="l.date" /></effDate>
+                        <desc><t t-esc="l.name" /></desc>
+                        <amnt><t t-esc="l.credit or l.debit" /></amnt>
+                        <amntTp><t t-esc="'C' if l.credit else 'D'" /></amntTp>
+                        <recRef t-if="l.reconcile_id"><t t-esc="l.reconcile_id.name" /></recRef>
+                        <custSupID t-if="l.partner_id"><t t-esc="l.partner_id.id" /></custSupID>
+                        <invRef t-if="l.invoice"><t t-esc="l.invoice.number" t-esc-options='{"widget": "auditfile.string999"}' /></invRef>
+                        <currency t-if="l.currency_id and l.amount_currency">
+                            <curCode><t t-esc="l.currency_id.name" /></curCode>
+                            <curAmnt><t t-esc="l.amount_currency" /></curAmnt>
+                        </currency>
+                    </trLine>
+                </transaction>
             </journal>
-          </transactions>
-        </company>
-      </auditfile>
-    </template>
-
-  </data>
+        </transactions>
+    </company>
+</auditfile>
+        </template>
+    </data>
 </openerp>

--- a/l10n_nl_xaf_auditfile_export/views/xaf_template_default.xml
+++ b/l10n_nl_xaf_auditfile_export/views/xaf_template_default.xml
@@ -26,7 +26,7 @@
             <country t-if="self.company_id.country_id"><t t-esc="self.company_id.country_id.code"/></country>
           </streetAddress>
           <customersSuppliers>
-            <customerSupplier t-foreach="self.get_partners()" t-as="p">
+            <customerSupplier t-foreach="self.get_partners(partner_ids)" t-as="p">
               <custSupID><t t-esc="p.id"/></custSupID>
               <custSupName><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}'/></custSupName>
               <taxRegistrationCountry t-if="p.country_id"><t t-esc="p.country_id.code"/></taxRegistrationCountry>
@@ -41,7 +41,7 @@
             </customerSupplier>
           </customersSuppliers>
           <generalLedger>
-            <ledgerAccount t-foreach="self.get_accounts()" t-as="a">
+            <ledgerAccount t-foreach="accounts" t-as="a">
               <accID><t t-esc="a.code"/></accID>
               <accDesc><t t-esc="a.name" t-esc-options='{"widget": "auditfile.string999"}'/></accDesc>
               <accTp><t t-esc="'P' if a.user_type.report_type in ['income', 'expense'] else 'B' if a.user_type.report_type in ['asset', 'liability'] else 'M'"/></accTp>
@@ -51,7 +51,7 @@
         <openingBalance />
         /-->
           <periods>
-            <period t-foreach="self.get_periods()" t-as="p">
+            <period t-foreach="periods" t-as="p">
               <periodNumber><t t-esc="p.id" /></periodNumber>
               <periodDesc><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}'/></periodDesc>
               <startDatePeriod><t t-esc="p.date_start"/></startDatePeriod>
@@ -59,14 +59,14 @@
             </period>
           </periods>
           <transactions>
-            <linesCount><t t-esc="self.get_move_line_count()"/></linesCount>
-            <totalDebit><t t-esc="self.get_move_line_total_debit()"/></totalDebit>
-            <totalCredit><t t-esc="self.get_move_line_total_credit()"/></totalCredit>
-            <journal t-foreach="self.get_journals()" t-as="j">
+            <linesCount><t t-esc="self.get_move_line_count(periods)"/></linesCount>
+            <totalDebit><t t-esc="self.get_move_line_total_debit(periods)"/></totalDebit>
+            <totalCredit><t t-esc="self.get_move_line_total_credit(periods)"/></totalCredit>
+            <journal t-foreach="journals" t-as="j">
               <jrnID><t t-esc="j.code"/></jrnID>
               <desc><t t-esc="j.name"/></desc>
               <jrnTp><t t-esc="'B' if j.type == 'bank' else 'C' if j.type == 'cash' else 'O' if j.type == 'situation' else 'S' if j.type in ['sale', 'sale_refund'] else 'P' if j.type in ['purchase', 'purchase_refund'] else 'Z'"/></jrnTp>
-              <transaction t-foreach="self.get_moves(j)" t-as="m">
+              <transaction t-foreach="self.get_moves(j, periods)" t-as="m">
                 <nr><t t-esc="m.id"/></nr>
                 <desc><t t-esc="m.name"/></desc>
                 <periodNumber><t t-esc="m.period_id.id"/></periodNumber>

--- a/l10n_nl_xaf_auditfile_export/views/xaf_template_default.xml
+++ b/l10n_nl_xaf_auditfile_export/views/xaf_template_default.xml
@@ -1,97 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
   <data>
-      <template id="xaf_template_default">
-<auditfile>
-    <header>
-        <fiscalYear><t t-esc="self.period_start.fiscalyear_id.name" t-esc-options='{"widget": "auditfile.string9"}' /></fiscalYear>
-        <startDate><t t-esc="self.period_start.date_start" /></startDate>
-        <endDate><t t-esc="self.period_end.date_stop" /></endDate>
-        <curCode><t t-esc="self.company_id.currency_id.name" /></curCode>
-        <dateCreated><t t-esc="self.date_generated[:10]" /></dateCreated>
-        <softwareDesc>Odoo</softwareDesc>
-        <softwareVersion><t t-esc="self.get_odoo_version()" t-esc-options='{"widget": "auditfile.string20"}' /></softwareVersion>
-    </header>
-    <company>
-        <companyIdent><t t-esc="self.company_id.company_registry" t-esc-options='{"widget": "auditfile.string35"}' /></companyIdent>
-        <companyName><t t-esc="self.company_id.name" t-esc-options='{"widget": "auditfile.string999"}' /></companyName>
-        <taxRegistrationCountry><t t-esc="self.company_id.country_id.code" /></taxRegistrationCountry>
-        <taxRegIdent><t t-esc="self.company_id.vat" t-esc-options='{"widget": "auditfile.string30"}' /></taxRegIdent>
-        <streetAddress>
-            <streetname><t t-esc="self.company_id.street" t-esc-options='{"widget": "auditfile.string999"}' /></streetname>
-            <city><t t-esc="self.company_id.city" t-esc-options='{"widget": "auditfile.string50"}' /></city>
-            <postalCode><t t-esc="self.company_id.zip" t-esc-options='{"widget": "auditfile.string15"}' /></postalCode>
-            <region><t t-esc="self.company_id.state_id.name" t-esc-options='{"widget": "auditfile.string50"}' /></region>
-            <country t-if="self.company_id.country_id"><t t-esc="self.company_id.country_id.code" /></country>
-        </streetAddress>
-        <customersSuppliers>
-            <customerSupplier t-foreach="self.get_partners(partner_ids)" t-as="p">
-                <custSupID><t t-esc="p.id" /></custSupID>
-                <custSupName><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}' /></custSupName>
-                <taxRegistrationCountry t-if="p.country_id"><t t-esc="p.country_id.code" /></taxRegistrationCountry>
-                <taxRegIdent><t t-esc="p.vat" t-esc-options='{"widget": "auditfile.string30"}' /></taxRegIdent>
-                <streetAddress>
-                    <streetname><t t-esc="p.street" t-esc-options='{"widget": "auditfile.string999"}' /></streetname>
-                    <city><t t-esc="p.city" t-esc-options='{"widget": "auditfile.string50"}' /></city>
-                    <postalCode><t t-esc="p.zip" t-esc-options='{"widget": "auditfile.string10"}' /></postalCode>
-                    <region><t t-esc="p.state_id.name" t-esc-options='{"widget": "auditfile.string50"}' /></region>
-                    <country t-if="p.country_id"><t t-esc="p.country_id.code" /></country>
-                </streetAddress>
-            </customerSupplier>
-        </customersSuppliers>
-        <generalLedger>
-            <ledgerAccount t-foreach="accounts" t-as="a">
-                <accID><t t-esc="a.code" /></accID>
-                <accDesc><t t-esc="a.name" t-esc-options='{"widget": "auditfile.string999"}' /></accDesc>
-                <accTp><t t-esc="'P' if a.user_type.report_type in ['income', 'expense'] else 'B' if a.user_type.report_type in ['asset', 'liability'] else 'M'" /></accTp>
-            </ledgerAccount>
-        </generalLedger>
-        <!-- we might fill in those later
-             <openingBalance />
-             /-->
-        <periods>
-            <period t-foreach="periods" t-as="p">
-                <periodNumber><t t-esc="p.id" /></periodNumber>
-                <periodDesc><t t-esc="p.name" t-esc-options='{"widget": "auditfile.string50"}' /></periodDesc>
-                <startDatePeriod><t t-esc="p.date_start" /></startDatePeriod>
-                <endDatePeriod><t t-esc="p.date_stop" /></endDatePeriod>
-            </period>
-        </periods>
-        <transactions>
-            <linesCount><t t-esc="self.get_move_line_count(periods)" /></linesCount>
-            <totalDebit><t t-esc="self.get_move_line_total_debit(periods)" /></totalDebit>
-            <totalCredit><t t-esc="self.get_move_line_total_credit(periods)" /></totalCredit>
-            <journal t-foreach="journals" t-as="j">
-                <jrnID><t t-esc="j.code" /></jrnID>
-                <desc><t t-esc="j.name" /></desc>
-                <jrnTp><t t-esc="'B' if j.type == 'bank' else 'C' if j.type == 'cash' else 'O' if j.type == 'situation' else 'S' if j.type in ['sale', 'sale_refund'] else 'P' if j.type in ['purchase', 'purchase_refund'] else 'Z'" /></jrnTp>
-                <transaction t-foreach="self.get_moves(j, periods)" t-as="m">
-                    <nr><t t-esc="m.id" /></nr>
-                    <desc><t t-esc="m.name" /></desc>
-                    <periodNumber><t t-esc="m.period_id.id" /></periodNumber>
-                    <trDt><t t-esc="m.date" /></trDt>
-                    <amnt><t t-esc="m.amount" /></amnt>
-                    <trLine t-foreach="m.line_id" t-as="l">
-                        <nr><t t-esc="l.id" /></nr>
-                        <accID><t t-esc="l.account_id.code" /></accID>
-                        <docRef><t t-esc="l.ref" t-esc-options='{"widget": "auditfile.string999"}' /></docRef>
-                        <effDate><t t-esc="l.date" /></effDate>
-                        <desc><t t-esc="l.name" /></desc>
-                        <amnt><t t-esc="l.credit or l.debit" /></amnt>
-                        <amntTp><t t-esc="'C' if l.credit else 'D'" /></amntTp>
-                        <recRef t-if="l.reconcile_id"><t t-esc="l.reconcile_id.name" /></recRef>
-                        <custSupID t-if="l.partner_id"><t t-esc="l.partner_id.id" /></custSupID>
-                        <invRef t-if="l.invoice"><t t-esc="l.invoice.number" t-esc-options='{"widget": "auditfile.string999"}' /></invRef>
-                        <currency t-if="l.currency_id and l.amount_currency">
-                            <curCode><t t-esc="l.currency_id.name" /></curCode>
-                            <curAmnt><t t-esc="l.amount_currency" /></curAmnt>
-                        </currency>
-                    </trLine>
-                </transaction>
-            </journal>
-        </transactions>
-    </company>
-</auditfile>
-        </template>
-    </data>
+      <template id="xaf_template_default" inherit_id="l10n_nl_xaf_auditfile_export.xaf_template_all" primary="True">
+          <xpath expr="//company/streetAddress/number" position="replace"/>
+          <xpath expr="//company/streetAddress/numberExtension" position="replace"/>
+          <xpath expr="//company/streetAddress/property" position="replace"/>
+          <xpath expr="//customerSupplier/contact" position="replace"/>
+          <xpath expr="//customerSupplier/telephone" position="replace"/>
+          <xpath expr="//customerSupplier/fax" position="replace"/>
+          <xpath expr="//customerSupplier/eMail" position="replace"/>
+          <xpath expr="//customerSupplier/website" position="replace"/>
+          <xpath expr="//customerSupplier/custSupTp" position="replace"/>
+          <xpath expr="//customerSupplier/custCreditLimit" position="replace"/>
+          <xpath expr="//customerSupplier/supplierLimit" position="replace"/>
+          <xpath expr="//customerSupplier/streetAddress/number" position="replace"/>
+          <xpath expr="//customerSupplier/streetAddress/numberExtension" position="replace"/>
+          <xpath expr="//customerSupplier/streetAddress/property" position="replace"/>
+          <xpath expr="//customerSupplier/bankAccount" position="replace"/>
+          <xpath expr="//customerSupplier/changeInfo" position="replace"/>
+          <xpath expr="//customerSupplier/customerSupplierHistory" position="replace"/>
+          <xpath expr="//generalLedger/ledgerAccount/changeInfo" position="replace"/>
+          <xpath expr="//generalLedger/ledgerAccount/glAccountHistory" position="replace"/>
+          <xpath expr="//periods/period/periodNumber" position="replace">
+              <periodNumber><t t-esc="p.id" /></periodNumber>
+          </xpath>
+          <xpath expr="//transactions/journal/transaction/periodNumber" position="replace">
+              <periodNumber><t t-esc="m.period_id.id" /></periodNumber>
+          </xpath>
+      </template>
+  </data>
 </openerp>


### PR DESCRIPTION
This PR fixes the XAF query to ensure that the partners, accounts and journals used in the selected periods are also included in the XAF file.
On the other hand partners, accounts and journals NOT involved in transactions in the selected periods are not relevant for the auditors and should not be included.
The level of detail of the export can also be selected. By default this level is limited to what required by external auditors since it's not a normal practice to e.g. give your customer database details to an external party.

This PR also includes PR https://github.com/OCA/l10n-netherlands/pull/101 (this fix really should be merged asap so that a XAF export no longer ends up in a python dump). 
