### PR TITLE
[10.0] l10n_nl_xaf_auditfile_export error with zero amounts

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -225,7 +225,7 @@ class XafAuditfileExport(models.Model):
             'and date <= \'' + self.date_end + '\' '
             'and (company_id=%s or company_id is null)',
             (self.company_id.id, ))
-        return self.env.cr.fetchall()[0][0]
+        return self.env.cr.fetchall()[0][0] or 0
 
     @api.multi
     def get_move_line_total_debit(self):
@@ -236,7 +236,7 @@ class XafAuditfileExport(models.Model):
             'and date <= \'' + self.date_end + '\' '
             'and (company_id=%s or company_id is null)',
             (self.company_id.id, ))
-        return self.env.cr.fetchall()[0][0]
+        return self.env.cr.fetchall()[0][0] or 0.0
 
     @api.multi
     def get_move_line_total_credit(self):
@@ -247,7 +247,7 @@ class XafAuditfileExport(models.Model):
             'and date <= \'' + self.date_end + '\' '
             'and (company_id=%s or company_id is null)',
             (self.company_id.id, ))
-        return self.env.cr.fetchall()[0][0]
+        return self.env.cr.fetchall()[0][0] or 0.0
 
     @api.multi
     def get_journals(self):


### PR DESCRIPTION
If the amount is zero, query returns nothing,
and generation will fail with error:

:31681:0:ERROR:SCHEMASV:SCHEMAV_CVC_DATATYPE_VALID_1_2_1: Element '{http://www.auditfiles.nl/XAF/3.2}totalDebit': '' is not a valid value of the atomic type '{http://www.auditfiles.nl/XAF/3.2}Amount2decimals'.