### PR TITLE
[11.0][IMP] l10n_nl_tax_statement: manage past undeclared invoices

### DIFF
--- a/l10n_nl_tax_statement/README.rst
+++ b/l10n_nl_tax_statement/README.rst
@@ -42,9 +42,17 @@ To create a statement you need to:
 #. Manually enter the BTW amounts of lines '5d', '5e', '5f' (in Edit mode, click on the amount of the line to be able to change it)
 #. Press the Post button to set the status of the statement to Posted; the statements set to this state cannot be modified
 
+To add past undeclared invoices:
+
+#. Open the tab `Past Undeclared Invoices`, available when the statement is in status Draft.
+#. Set an initial date (field From Date) from which the past undeclared invoices will be displayed.
+#. One by one, add the displayed undeclared invoices, by clicking on the `Add Invoice` button present in each line.
+#. Press the Update button in order to recompute the statement lines.
+
 Extra info about the workflow:
 
 #. If you need to recalculate or modify or delete a statement already set to Posted status you need first to set it back to Draft status: press the button Reset to Draft
+#. Instead, if you send the statement to the Tax Authority, you may want to avoid that the statement is set back to Draft: to avoid this, press the button Final. If you then confirm, it will be not possible to modify this Statement or reset it back to draft anymore.
 
 Printing a PDF report:
 
@@ -60,7 +68,6 @@ Known issues / Roadmap
 ======================
 
 * Exporting in SBR/XBLR format not yet available
-* Including in the report being created, not only the data filtered by the selected date range, but also all the old data that was not included in the previous tax declarations (work in progress...)
 
 Bug Tracker
 ===========

--- a/l10n_nl_tax_statement/__manifest__.py
+++ b/l10n_nl_tax_statement/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'Localization',
     'license': 'AGPL-3',
     'author': 'Onestein, Odoo Community Association (OCA)',
-    'website': 'http://www.onestein.eu',
+    'website': 'https://github.com/OCA/l10n-netherlands',
     'depends': [
         'account_tax_balance',
     ],

--- a/l10n_nl_tax_statement/__manifest__.py
+++ b/l10n_nl_tax_statement/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Netherlands BTW Statement',
-    'version': '11.0.1.1.0',
+    'version': '11.0.2.0.0',
     'category': 'Localization',
     'license': 'AGPL-3',
     'author': 'Onestein, Odoo Community Association (OCA)',

--- a/l10n_nl_tax_statement/i18n/nl.po
+++ b/l10n_nl_tax_statement/i18n/nl.po
@@ -97,11 +97,6 @@ msgid "5b"
 msgstr "5b"
 
 #. module: l10n_nl_tax_statement
-#: model:ir.ui.view,arch_db:l10n_nl_tax_statement.view_account_vat_statement_nl_config
-msgid "5b bis"
-msgstr "5b bis"
-
-#. module: l10n_nl_tax_statement
 #: model:ir.model.fields,field_description:l10n_nl_tax_statement.field_l10n_nl_vat_statement_format_btw_total
 msgid "5g - Total"
 msgstr "5g - Totaal"
@@ -538,12 +533,6 @@ msgstr "Tag 4B Omzet"
 #: model:ir.model.fields,field_description:l10n_nl_tax_statement.field_l10n_nl_vat_statement_config_wizard_tag_5b_btw
 msgid "Tag 5B Btw"
 msgstr "Tag 5B Btw"
-
-#. module: l10n_nl_tax_statement
-#: model:ir.model.fields,field_description:l10n_nl_tax_statement.field_l10n_nl_vat_statement_config_tag_5b_btw_bis
-#: model:ir.model.fields,field_description:l10n_nl_tax_statement.field_l10n_nl_vat_statement_config_wizard_tag_5b_btw_bis
-msgid "Tag 5B Btw Bis"
-msgstr "Tag 5B Btw Bis"
 
 #. module: l10n_nl_tax_statement
 #: code:addons/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py:221

--- a/l10n_nl_tax_statement/migrations/11.0.2.0.0/post-migrate.py
+++ b/l10n_nl_tax_statement/migrations/11.0.2.0.0/post-migrate.py
@@ -1,0 +1,22 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api
+from odoo import SUPERUSER_ID
+
+
+def migrate(cr, version):
+    '''
+    Replace Tag "Voorbelasting (BTW) bis" with  Tag "5b. Voorbelasting (BTW)"
+    '''
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    tag_5b_btw = env.ref('l10n_nl.tag_nl_33', False)
+    tag_5b_btw_bis = env.ref('l10n_nl.tag_nl_34', False)
+
+    if tag_5b_btw and tag_5b_btw_bis:
+        cr.execute('''
+        UPDATE account_account_tag_account_tax_template_rel
+            SET account_account_tag_id=%s
+            WHERE account_account_tag_id=%s
+        ''', (tag_5b_btw_bis.id, tag_5b_btw.id))

--- a/l10n_nl_tax_statement/models/__init__.py
+++ b/l10n_nl_tax_statement/models/__init__.py
@@ -1,3 +1,6 @@
 from . import l10n_nl_vat_statement
 from . import l10n_nl_vat_statement_line
 from . import l10n_nl_vat_statement_config
+from . import account_move
+from . import account_move_line
+from . import account_tax

--- a/l10n_nl_tax_statement/models/account_move.py
+++ b/l10n_nl_tax_statement/models/account_move.py
@@ -1,0 +1,24 @@
+# Copyright 2017 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    l10n_nl_vat_statement_id = fields.Many2one(
+        'l10n.nl.vat.statement',
+        'Statement'
+    )
+    l10n_nl_vat_statement_include = fields.Boolean(
+        'Include in VAT Statement'
+    )
+
+    def add_move_in_statement(self):
+        for move in self:
+            move.l10n_nl_vat_statement_include = True
+
+    def unlink_move_from_statement(self):
+        for move in self:
+            move.l10n_nl_vat_statement_include = False

--- a/l10n_nl_tax_statement/models/account_move_line.py
+++ b/l10n_nl_tax_statement/models/account_move_line.py
@@ -11,7 +11,7 @@ class AccountMoveLine(models.Model):
         related='move_id.l10n_nl_vat_statement_id',
         store=True,
         readonly=True,
-        string='Statement'
+        string='Related Move Statement'
     )
     l10n_nl_vat_statement_include = fields.Boolean(
         related='move_id.l10n_nl_vat_statement_include',

--- a/l10n_nl_tax_statement/models/account_move_line.py
+++ b/l10n_nl_tax_statement/models/account_move_line.py
@@ -1,0 +1,20 @@
+# Copyright 2017 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    l10n_nl_vat_statement_id = fields.Many2one(
+        related='move_id.l10n_nl_vat_statement_id',
+        store=True,
+        readonly=True,
+        string='Statement'
+    )
+    l10n_nl_vat_statement_include = fields.Boolean(
+        related='move_id.l10n_nl_vat_statement_include',
+        store=True,
+        readonly=True
+    )

--- a/l10n_nl_tax_statement/models/account_tax.py
+++ b/l10n_nl_tax_statement/models/account_tax.py
@@ -1,0 +1,64 @@
+# Copyright 2017 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class AccountTax(models.Model):
+    _inherit = 'account.tax'
+
+    def get_move_line_partial_domain(self, from_date, to_date, company_id):
+
+        res = super(AccountTax, self).get_move_line_partial_domain(
+            from_date,
+            to_date,
+            company_id
+        )
+
+        if self._context.get('skip_invoice_basis_domain'):
+            company = self.env['res.company'].browse(company_id)
+            is_nl = company.country_id == self.env.ref('base.nl')
+            if is_nl:
+                res = [
+                    ('company_id', '=', company_id),
+                    ('l10n_nl_vat_statement_id', '=', False),
+                    ('l10n_nl_vat_statement_include', '=', True),
+                ]
+                res += self._get_move_line_tax_date_range_domain(from_date)
+        return res
+
+    @api.model
+    def _get_move_line_tax_date_range_domain(self, from_date):
+        unreported_from_date = self._context.get('unreported_move_from_date')
+        if self._context.get('is_invoice_basis'):
+            if unreported_from_date:
+                res = [
+                    '|',
+                    '&', '&',
+                    ('l10n_nl_date_invoice', '=', False),
+                    ('date', '<', from_date),
+                    ('date', '>=', unreported_from_date),
+                    '&', '&',
+                    ('l10n_nl_date_invoice', '!=', False),
+                    ('l10n_nl_date_invoice', '<', from_date),
+                    ('l10n_nl_date_invoice', '>=', unreported_from_date),
+                ]
+            else:
+                res = [
+                    '|',
+                    '&',
+                    ('l10n_nl_date_invoice', '=', False),
+                    ('date', '<', from_date),
+                    '&',
+                    ('l10n_nl_date_invoice', '!=', False),
+                    ('l10n_nl_date_invoice', '<', from_date),
+                ]
+        else:
+            res = [
+                ('date', '<', from_date),
+            ]
+            if unreported_from_date:
+                res += [
+                    ('date', '>=', unreported_from_date),
+                ]
+        return res

--- a/l10n_nl_tax_statement/models/account_tax.py
+++ b/l10n_nl_tax_statement/models/account_tax.py
@@ -1,47 +1,49 @@
-# Copyright 2017 Onestein (<http://www.onestein.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2017-2018 Onestein (<https://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, models
+from odoo.osv import expression
 
 
 class AccountTax(models.Model):
     _inherit = 'account.tax'
 
     def get_move_line_partial_domain(self, from_date, to_date, company_id):
-
         res = super(AccountTax, self).get_move_line_partial_domain(
             from_date,
             to_date,
             company_id
         )
 
-        if self._context.get('skip_invoice_basis_domain'):
-            company = self.env['res.company'].browse(company_id)
-            is_nl = company.country_id == self.env.ref('base.nl')
-            if is_nl:
-                res = [
-                    ('company_id', '=', company_id),
-                    ('l10n_nl_vat_statement_id', '=', False),
-                    ('l10n_nl_vat_statement_include', '=', True),
-                ]
-                res += self._get_move_line_tax_date_range_domain(from_date)
-        return res
+        if not self.env.context.get('skip_invoice_basis_domain'):
+            return res
+
+        company = self.env['res.company'].browse(company_id)
+        if company.country_id != self.env.ref('base.nl'):
+            return res
+
+        return expression.AND([
+            [('company_id', '=', company_id)],
+            [('l10n_nl_vat_statement_id', '=', False)],
+            [('l10n_nl_vat_statement_include', '=', True)],
+            self._get_move_line_tax_date_range_domain(from_date),
+        ])
 
     @api.model
     def _get_move_line_tax_date_range_domain(self, from_date):
-        unreported_from_date = self._context.get('unreported_move_from_date')
-        if self._context.get('is_invoice_basis'):
-            if unreported_from_date:
+        unreported_date = self.env.context.get('unreported_move_from_date')
+        if self.env.context.get('is_invoice_basis'):
+            if unreported_date:
                 res = [
                     '|',
                     '&', '&',
                     ('l10n_nl_date_invoice', '=', False),
                     ('date', '<', from_date),
-                    ('date', '>=', unreported_from_date),
+                    ('date', '>=', unreported_date),
                     '&', '&',
                     ('l10n_nl_date_invoice', '!=', False),
                     ('l10n_nl_date_invoice', '<', from_date),
-                    ('l10n_nl_date_invoice', '>=', unreported_from_date),
+                    ('l10n_nl_date_invoice', '>=', unreported_date),
                 ]
             else:
                 res = [
@@ -57,8 +59,8 @@ class AccountTax(models.Model):
             res = [
                 ('date', '<', from_date),
             ]
-            if unreported_from_date:
+            if unreported_date:
                 res += [
-                    ('date', '>=', unreported_from_date),
+                    ('date', '>=', unreported_date),
                 ]
         return res

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
@@ -331,7 +331,6 @@ class VatStatement(models.Model):
             config.tag_4b_omzet.id: ('4b', 'omzet'),
             config.tag_4b_btw.id: ('4b', 'btw'),
             config.tag_5b_btw.id: ('5b', 'btw'),
-            config.tag_5b_btw_bis.id: ('5b', 'btw'),
         }
 
     @api.multi

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
@@ -325,6 +325,7 @@ class VatStatement(models.Model):
             config.tag_2a_btw.id: ('2a', 'btw'),
             config.tag_3a_omzet.id: ('3a', 'omzet'),
             config.tag_3b_omzet.id: ('3b', 'omzet'),
+            config.tag_3b_omzet_d.id: ('3b', 'omzet'),
             config.tag_3c_omzet.id: ('3c', 'omzet'),
             config.tag_4a_omzet.id: ('4a', 'omzet'),
             config.tag_4a_btw.id: ('4a', 'btw'),

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
@@ -12,6 +12,7 @@ from odoo.tools.misc import formatLang
 
 class VatStatement(models.Model):
     _name = 'l10n.nl.vat.statement'
+    _description = 'Netherlands Vat Statement'
 
     name = fields.Char(
         string='Tax Statement',
@@ -126,7 +127,7 @@ class VatStatement(models.Model):
         string="Unreported Journal Entries",
         compute='_compute_unreported_move_ids'
     )
-    unreported_move_from_date = fields.Date('From Date')
+    unreported_move_from_date = fields.Date()
 
     @api.multi
     def _compute_is_invoice_basis(self):

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement_config.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement_config.py
@@ -6,6 +6,7 @@ from odoo import fields, models
 
 class VatStatementConfig(models.Model):
     _name = 'l10n.nl.vat.statement.config'
+    _description = 'Netherlands Vat Statement Configuration'
 
     company_id = fields.Many2one(
         'res.company',

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement_config.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement_config.py
@@ -26,6 +26,7 @@ class VatStatementConfig(models.Model):
     tag_2a_btw = fields.Many2one('account.account.tag')
     tag_3a_omzet = fields.Many2one('account.account.tag')
     tag_3b_omzet = fields.Many2one('account.account.tag')
+    tag_3b_omzet_d = fields.Many2one('account.account.tag')
     tag_3c_omzet = fields.Many2one('account.account.tag')
     tag_4a_omzet = fields.Many2one('account.account.tag')
     tag_4a_btw = fields.Many2one('account.account.tag')

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement_config.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement_config.py
@@ -32,4 +32,3 @@ class VatStatementConfig(models.Model):
     tag_4b_omzet = fields.Many2one('account.account.tag')
     tag_4b_btw = fields.Many2one('account.account.tag')
     tag_5b_btw = fields.Many2one('account.account.tag')
-    tag_5b_btw_bis = fields.Many2one('account.account.tag')

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement_line.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement_line.py
@@ -1,10 +1,9 @@
 # Copyright 2017 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models, _
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 from odoo.tools.misc import formatLang
-from odoo.exceptions import Warning as UserError
-
 
 OMZET_DISPLAY = (
     '1a', '1b', '1c', '1d', '1e',
@@ -89,4 +88,7 @@ class VatStatementLine(models.Model):
                 raise UserError(
                     _('You cannot delete lines of a posted statement! '
                       'Reset the statement to draft first.'))
+            if line.statement_id.state == 'final':
+                raise UserError(
+                    _('You cannot delete lines of a statement set as final!'))
         super(VatStatementLine, self).unlink()

--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement_line.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement_line.py
@@ -30,6 +30,7 @@ EDITABLE_DISPLAY = (
 
 class VatStatementLine(models.Model):
     _name = 'l10n.nl.vat.statement.line'
+    _description = 'Netherlands Vat Statement Line'
     _order = 'code'
 
     name = fields.Char()
@@ -53,8 +54,6 @@ class VatStatementLine(models.Model):
     is_group = fields.Boolean(compute='_compute_is_group')
     is_readonly = fields.Boolean(compute='_compute_is_readonly')
 
-    state = fields.Selection(related='statement_id.state')
-
     @api.multi
     @api.depends('omzet', 'btw', 'code')
     def _compute_amount_format(self):
@@ -76,7 +75,7 @@ class VatStatementLine(models.Model):
     @api.depends('code')
     def _compute_is_readonly(self):
         for line in self:
-            if line.state == 'draft':
+            if line.statement_id.state == 'draft':
                 line.is_readonly = line.code not in EDITABLE_DISPLAY
             else:
                 line.is_readonly = True

--- a/l10n_nl_tax_statement/readme/CONFIGURE.rst
+++ b/l10n_nl_tax_statement/readme/CONFIGURE.rst
@@ -1,0 +1,10 @@
+This module makes use of the tax tags (eg.: 1a, 1b, 1c, 1d, 2a...) as prescribed by the Dutch tax laws.
+
+If the default Odoo Dutch chart of accounts is installed (module ``l10n_nl``) then these tags are automatically present in the database.
+If this is the case, go to menu: `Invoicing -> Configuration -> Accounting -> NL BTW Tags`, and check that the tags are correctly set; click Apply to confirm.
+
+If a non-standard chart of accounts is installed, you have to manually create the tax tags and properly set them into the tax definition.
+After that, go to go to menu: `Invoicing -> Configuration -> Accounting -> NL BTW Tags`, and manually set the tags in the configuration form; click Apply to confirm.
+
+If your Company adopts the *Factuurstelsel* system for the accounting, also install the module ``l10n_nl_tax_invoice_basis``
+(for more information about the installation and configuration of that module, check the README file).

--- a/l10n_nl_tax_statement/readme/CONTRIBUTORS.rst
+++ b/l10n_nl_tax_statement/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Andrea Stirpe <a.stirpe@onestein.nl>
+* Antonio Esposito <a.esposito@onestein.nl>

--- a/l10n_nl_tax_statement/readme/DESCRIPTION.rst
+++ b/l10n_nl_tax_statement/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module provides you with the Tax Statement in the Dutch format.
+
+Use this module in combination with module ``l10n_nl_tax_invoice_basis`` if you want to adopt the *Factuurstelsel* system for your Company.

--- a/l10n_nl_tax_statement/readme/HISTORY.rst
+++ b/l10n_nl_tax_statement/readme/HISTORY.rst
@@ -1,0 +1,46 @@
+11.0.2.0.0
+~~~~~~~~~~
+
+* Added new feature: management of past undeclared invoices
+  https://github.com/OCA/l10n-netherlands/pull/139
+
+11.0.1.0.1
+~~~~~~~~~~
+
+* Bug fixing: printing report
+  https://github.com/OCA/l10n-netherlands/pull/145
+
+11.0.1.0.0
+~~~~~~~~~~
+
+* Porting to V11
+  https://github.com/OCA/l10n-netherlands/pull/126
+
+10.0.1.2.0
+~~~~~~~~~~
+
+* Bug fixing: CSS Namespace conflicting with account_financial_report_qweb
+
+10.0.1.1.1
+~~~~~~~~~~
+
+* Bug fixing: Omzet 1a-4b: check and invert the sign
+
+10.0.1.1.0
+~~~~~~~~~~
+
+* Lines 5d, 5e, 5f and 5g added in report
+  https://github.com/OCA/l10n-netherlands/pull/107
+
+10.0.1.0.1
+~~~~~~~~~~
+
+* Bug fixing
+  https://github.com/OCA/l10n-netherlands/pull/97
+  https://github.com/OCA/l10n-netherlands/pull/93
+
+10.0.1.0.0
+~~~~~~~~~~
+
+* Initial release.
+  https://github.com/OCA/l10n-netherlands/pull/70

--- a/l10n_nl_tax_statement/readme/INSTALL.rst
+++ b/l10n_nl_tax_statement/readme/INSTALL.rst
@@ -1,0 +1,2 @@
+* This module depends on module ``account_tax_balance`` available at https://github.com/OCA/account-financial-reporting.
+* This module also depends on module ``date_range`` that is supported as of postgresql 9.2 or later versions.

--- a/l10n_nl_tax_statement/readme/ROADMAP.rst
+++ b/l10n_nl_tax_statement/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+* Exporting in SBR/XBLR format not yet available

--- a/l10n_nl_tax_statement/readme/USAGE.rst
+++ b/l10n_nl_tax_statement/readme/USAGE.rst
@@ -1,0 +1,24 @@
+To create a statement you need to:
+
+#. Verify that you have enough permits. You need to belong at least to the Accountant group.
+#. Go to the menu: `Invoicing -> Reports > Taxes Balance > NL BTW Statement`
+#. Create a statement, providing a name and specifying start date and end date
+#. Press the Update button to calculate the report: the report lines will be displayed in the tab `Statement`
+#. Manually enter the BTW amounts of lines '5d', '5e', '5f' (in Edit mode, click on the amount of the line to be able to change it)
+#. Press the Post button to set the status of the statement to Posted; the statements set to this state cannot be modified
+
+To add past undeclared invoices:
+
+#. Open the tab `Past Undeclared Invoices`, available when the statement is in status Draft.
+#. Set an initial date (field From Date) from which the past undeclared invoices will be displayed.
+#. One by one, add the displayed undeclared invoices, by clicking on the `Add Invoice` button present in each line.
+#. Press the Update button in order to recompute the statement lines.
+
+Extra info about the workflow:
+
+#. If you need to recalculate or modify or delete a statement already set to Posted status you need first to set it back to Draft status: press the button Reset to Draft
+#. Instead, if you send the statement to the Tax Authority, you may want to avoid that the statement is set back to Draft: to avoid this, press the button Final. If you then confirm, it will be not possible to modify this Statement or reset it back to draft anymore.
+
+Printing a PDF report:
+
+#. If you need to print the report in PDF, open a statement form and click: `Print -> NL Tax Statement`

--- a/l10n_nl_tax_statement/tests/test_l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/tests/test_l10n_nl_vat_statement.py
@@ -30,9 +30,16 @@ class TestVatStatement(TransactionCase):
             'name': 'Tag 1',
             'applicability': 'taxes',
         })
-
         self.tag_2 = self.Tag.create({
             'name': 'Tag 2',
+            'applicability': 'taxes',
+        })
+        self.tag_3 = self.Tag.create({
+            'name': 'Tag 3',
+            'applicability': 'taxes',
+        })
+        self.tag_4 = self.Tag.create({
+            'name': 'Tag 4',
             'applicability': 'taxes',
         })
 
@@ -52,6 +59,8 @@ class TestVatStatement(TransactionCase):
             'company_id': self.env.user.company_id.id,
             'tag_1a_omzet': self.tag_1.id,
             'tag_1a_btw': self.tag_2.id,
+            'tag_3b_omzet': self.tag_3.id,
+            'tag_3b_omzet_d': self.tag_4.id,
         })
 
         self.daterange_type = self.DateRangeType.create({'name': 'Type 1'})

--- a/l10n_nl_tax_statement/tests/test_l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/tests/test_l10n_nl_vat_statement.py
@@ -1,9 +1,13 @@
 # Copyright 2017 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.exceptions import Warning as UserError
-from odoo.tests.common import TransactionCase
 from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase, at_install, post_install
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT as DF
 
 
 class TestVatStatement(TransactionCase):
@@ -82,7 +86,7 @@ class TestVatStatement(TransactionCase):
             'partner_id': self.partner.id,
             'account_id': invoice_line_account,
             'journal_id': self.journal_1.id,
-            'date_invoice': datetime.today(),
+            'date_invoice': fields.Date.today(),
             'type': 'out_invoice',
         })
 
@@ -116,20 +120,55 @@ class TestVatStatement(TransactionCase):
             [self.statement_1.from_date, self.statement_1.to_date])
         self.assertEqual(self.statement_1.name, check_name)
 
-    def test_02_post(self):
+        self.statement_1.onchange_date_from_date()
+        d_from = datetime.strptime(self.statement_1.from_date, DF)
+        # by default the unreported_move_from_date is set to
+        # a quarter (three months) before the from_date of the statement
+        d_from_2months = d_from + relativedelta(months=-3, day=1)
+        new_date = fields.Date.to_string(d_from_2months)
+        self.assertEqual(self.statement_1.unreported_move_from_date, new_date)
+
+        self.assertEqual(self.statement_1.btw_total, 0.)
+
+    def test_02_post_final(self):
+        # first post
+        self.statement_1.statement_update()
         self.statement_1.post()
         self.assertEqual(self.statement_1.state, 'posted')
         self.assertTrue(self.statement_1.date_posted)
+
+        # then finalize
+        self.statement_1.finalize()
+        self.assertEqual(self.statement_1.state, 'final')
+        self.assertTrue(self.statement_1.date_posted)
+
+        with self.assertRaises(UserError):
+            self.statement_1.write({'name': 'Test Name Modified'})
+        with self.assertRaises(UserError):
+            self.statement_1.write({'state': 'posted'})
+        with self.assertRaises(UserError):
+            self.statement_1.write({'date_posted': fields.Datetime.now()})
+        with self.assertRaises(UserError):
+            self.statement_1.unlink()
+        for line in self.statement_1.line_ids:
+            with self.assertRaises(UserError):
+                line.unlink()
+
+        self.assertEqual(self.statement_1.btw_total, 0.)
 
     def test_03_reset(self):
         self.statement_1.reset()
         self.assertEqual(self.statement_1.state, 'draft')
         self.assertFalse(self.statement_1.date_posted)
 
+        self.assertEqual(self.statement_1.btw_total, 0.)
+
     def test_04_write(self):
         self.statement_1.post()
         with self.assertRaises(UserError):
             self.statement_1.write({'name': 'Test Name'})
+
+        self.assertEqual(self.statement_1.btw_total, 0.)
 
     def test_05_unlink_exception(self):
         self.statement_1.post()
@@ -166,10 +205,15 @@ class TestVatStatement(TransactionCase):
         self.assertFalse(_1.format_omzet)
         self.assertFalse(_1.format_btw)
         self.assertTrue(_1.is_group)
+        self.assertTrue(_1.is_readonly)
 
         self.assertEqual(_1a.format_omzet, '100.00')
         self.assertEqual(_1a.format_btw, '10.50')
         self.assertFalse(_1a.is_group)
+        self.assertTrue(_1.is_readonly)
+
+        self.assertEqual(self.statement_1.btw_total, 10.5)
+        self.assertEqual(self.statement_1.format_btw_total, '10.50')
 
     def test_10_line_unlink_exception(self):
         self.invoice_1.action_invoice_open()
@@ -177,6 +221,11 @@ class TestVatStatement(TransactionCase):
         self.statement_1.post()
         with self.assertRaises(UserError):
             self.statement_1.line_ids.unlink()
+
+        self.assertEqual(self.statement_1.btw_total, 0.)
+
+        for line in self.statement_1.line_ids:
+            self.assertTrue(line.is_readonly)
 
     def test_11_wizard_execute(self):
         wizard = self.Wizard.create({})
@@ -208,3 +257,115 @@ class TestVatStatement(TransactionCase):
         self.assertTrue(config)
         self.assertEqual(config.tag_1a_btw, self.tag_1)
         self.assertEqual(config.tag_1a_omzet, self.tag_2)
+
+        self.assertEqual(self.statement_1.btw_total, 0.)
+
+    def test_12_undeclared_invoice(self):
+        self.invoice_1._onchange_invoice_line_ids()
+        self.invoice_1.action_invoice_open()
+        self.invoice_1.move_id.add_move_in_statement()
+        for line in self.invoice_1.move_id.line_ids:
+            self.assertEqual(line.l10n_nl_vat_statement_include, True)
+        self.invoice_1.move_id.unlink_move_from_statement()
+        for line in self.invoice_1.move_id.line_ids:
+            self.assertEqual(line.l10n_nl_vat_statement_include, False)
+
+        self.statement_1.statement_update()
+        self.assertEqual(len(self.statement_1.line_ids.ids), 22)
+        self.statement_1.post()
+
+        invoice2 = self.invoice_1.copy()
+        invoice2._onchange_invoice_line_ids()
+        invoice2.action_invoice_open()
+        statement2 = self.Statement.create({
+            'name': 'Statement 2',
+        })
+        statement2.statement_update()
+        statement2.unreported_move_from_date = fields.Date.today()
+        statement2.onchange_unreported_move_from_date()
+        self.assertFalse(statement2.unreported_move_ids)
+
+        self.assertEqual(self.statement_1.btw_total, 10.5)
+        self.assertEqual(self.statement_1.format_btw_total, '10.50')
+
+        for line in self.statement_1.line_ids:
+            self.assertTrue(line.is_readonly)
+
+    def test_13_no_previous_statement_posted(self):
+        statement2 = self.Statement.create({
+            'name': 'Statement 2',
+        })
+        statement2.statement_update()
+        with self.assertRaises(UserError):
+            statement2.post()
+
+        self.assertEqual(self.statement_1.btw_total, 0.)
+        self.assertEqual(self.statement_1.format_btw_total, '0.00')
+
+        for line in self.statement_1.line_ids:
+            self.assertFalse(line.is_readonly)
+
+    @at_install(False)
+    @post_install(True)
+    def test_14_is_invoice_basis(self):
+        company = self.statement_1.company_id
+        has_invoice_basis = self.env['ir.model.fields'].sudo().search_count([
+            ('model', '=', 'res.company'),
+            ('name', '=', 'l10n_nl_tax_invoice_basis')
+        ])
+        if has_invoice_basis:
+            company.l10n_nl_tax_invoice_basis = True
+            self.statement_1._compute_is_invoice_basis()
+            self.assertEqual(self.statement_1.is_invoice_basis, True)
+            company.l10n_nl_tax_invoice_basis = False
+            self.statement_1._compute_is_invoice_basis()
+            self.assertEqual(self.statement_1.is_invoice_basis, False)
+
+        self.assertEqual(self.statement_1.btw_total, 0.)
+        self.assertEqual(self.statement_1.format_btw_total, '0.00')
+
+        for line in self.statement_1.line_ids:
+            self.assertTrue(line.is_readonly)
+
+    @at_install(False)
+    @post_install(True)
+    def test_15_invoice_basis_undeclared_invoice(self):
+        self.invoice_1._onchange_invoice_line_ids()
+        self.invoice_1.action_invoice_open()
+        self.statement_1.statement_update()
+        self.assertEqual(len(self.statement_1.line_ids.ids), 22)
+        self.statement_1.with_context(
+            skip_check_config_tag_3b_omzet=True
+        ).post()
+
+        has_invoice_basis = self.env['ir.model.fields'].sudo().search_count([
+            ('model', '=', 'res.company'),
+            ('name', '=', 'l10n_nl_tax_invoice_basis')
+        ])
+        if has_invoice_basis:
+
+            self.statement_1.company_id.l10n_nl_tax_invoice_basis = True
+            self.statement_1.company_id.country_id = self.env.ref('base.nl')
+
+            invoice2 = self.invoice_1.copy()
+            d_date = datetime.strptime(fields.Date.today(), DF)
+            d_date = d_date + relativedelta(months=-4, day=1)
+            old_date = fields.Date.to_string(d_date)
+            invoice2.date_invoice = old_date
+            invoice2.action_invoice_open()
+
+            statement2 = self.Statement.create({
+                'name': 'Statement 2',
+            })
+            statement2.unreported_move_from_date = fields.Date.today()
+            statement2.onchange_unreported_move_from_date()
+            statement2.statement_update()
+            statement2.with_context(
+                skip_check_config_tag_3b_omzet=True
+            ).post()
+
+        self.assertEqual(self.statement_1.btw_total, 10.5)
+        self.assertEqual(self.statement_1.format_btw_total, '10.50')
+
+        for line in self.statement_1.line_ids:
+            self.assertTrue(line.is_readonly)

--- a/l10n_nl_tax_statement/views/l10n_nl_vat_statement_view.xml
+++ b/l10n_nl_tax_statement/views/l10n_nl_vat_statement_view.xml
@@ -79,7 +79,7 @@
                         <page name="entry_lines" string="Past Undeclared Invoices" attrs="{'invisible':[('state','!=','draft')]}">
                             <group name="unreported_move_filter" string="Include Undeclared Invoices">
                                 <group>
-                                    <field name="unreported_move_from_date" attrs="{'readonly': [('state','in',['posted','final'])]}"/>
+                                    <field name="unreported_move_from_date" string="From Date" attrs="{'readonly': [('state','in',['posted','final'])]}"/>
                                 </group>
                                 <group>
                                 </group>

--- a/l10n_nl_tax_statement/views/l10n_nl_vat_statement_view.xml
+++ b/l10n_nl_tax_statement/views/l10n_nl_vat_statement_view.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Onestein (<http://www.onestein.eu>)
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
 <odoo>
 
     <record id="view_l10n_nl_vat_report_form" model="ir.ui.view">
@@ -6,13 +9,13 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <button name="reset" string="Reset to Draft" states="posted" type="object"/>
-                    <field name="state" widget="statusbar" statusbar_visible="draft,posted"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,posted,final"/>
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button name="statement_update" string="Update" states="draft" type="object" class="oe_stat_button" icon="fa-repeat"/>
                         <button name="post" string="Post" states="draft" type="object" class="oe_stat_button" icon="fa-arrow-right text-success"/>
+                        <button name="reset" string="Reset to Draft" states="posted" type="object" class="oe_stat_button" icon="fa-arrow-left text-success"/>
+                        <button name="finalize" string="Finalize" states="posted" type="object" class="oe_stat_button" icon="fa-stop-circle-o text-success" confirm="If you confirm, it will be not possible to modify this Statement or reset it back to draft anymore. Do you confirm?"/>
                     </div>
                     <label for="name"/>
                     <h1>
@@ -21,9 +24,9 @@
                     <group>
                         <group name="tax_report">
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
-                            <field name="date_range_id" attrs="{'readonly': [('state','=','posted')]}"/>
-                            <field name="from_date" attrs="{'readonly': [('state','=','posted')]}"/>
-                            <field name="to_date" attrs="{'readonly': [('state','=','posted')]}"/>
+                            <field name="date_range_id" attrs="{'readonly': [('state','in',['posted','final'])]}"/>
+                            <field name="from_date" attrs="{'readonly': [('state','in',['posted','final'])]}"/>
+                            <field name="to_date" attrs="{'readonly': [('state','in',['posted','final'])]}"/>
                         </group>
                         <group name="extra_parameters">
                             <field name="date_posted"/>
@@ -33,7 +36,13 @@
                         </group>
                     </group>
                     <notebook name="notebook">
-                        <page name="statement" string="Statement">
+                        <page name="statement" string="BTW Statement">
+                            <group name="statement_lines" string="BTW Statement lines">
+                                <div states="draft">Press the Update button in order to recompute the statement lines!</div>
+                                <div class="oe_button_box" name="button_box">
+                                    <button name="statement_update" string="Update" states="draft" type="object" class="oe_stat_button" icon="fa-repeat"/>
+                                </div>
+                            </group>
                             <field name="line_ids">
                                 <form>
                                     <group>
@@ -47,7 +56,7 @@
                                         </group>
                                     </group>
                                 </form>
-                                <tree colors="grey:is_group" editable="bottom" create="false" delete="false">
+                                <tree decoration-muted="is_group" editable="bottom" create="false" delete="false">
                                     <field name="is_group" invisible="1"/>
                                     <field name="is_readonly" invisible="1"/>
                                     <field name="code" readonly="1"/>
@@ -66,6 +75,31 @@
                                     <field name="btw_total" nolabel="1"/>
                                 </group>
                             </group>
+                        </page>
+                        <page name="entry_lines" string="Past Undeclared Invoices" attrs="{'invisible':[('state','!=','draft')]}">
+                            <group name="unreported_move_filter" string="Include Undeclared Invoices">
+                                <group>
+                                    <field name="unreported_move_from_date" attrs="{'readonly': [('state','in',['posted','final'])]}"/>
+                                </group>
+                                <group>
+                                </group>
+                                <div>Add/Remove the Undeclared Invoices listed below. Afterwards press the Update button in order to recompute the statement lines!</div>
+                                <div class="oe_button_box" name="button_box">
+                                    <button name="statement_update" string="Update" states="draft" type="object" class="oe_stat_button" icon="fa-repeat"/>
+                                </div>
+                            </group>
+                            <field name="unreported_move_ids">
+                                <tree editable="bottom" create="false" delete="false" decoration-muted="l10n_nl_vat_statement_include != True">
+                                    <field name="date" readonly="1"/>
+                                    <field name="name" readonly="1"/>
+                                    <field name="journal_id" readonly="1"/>
+                                    <field name="partner_id" readonly="1"/>
+                                    <field name="amount" readonly="1"/>
+                                    <field name="l10n_nl_vat_statement_include" invisible="1"/>
+                                    <button name="add_move_in_statement" icon="fa fa-play" string="Add Invoice" type="object" attrs="{'invisible': [('l10n_nl_vat_statement_include', '=', True)]}"/>
+                                    <button name="unlink_move_from_statement" icon="fa fa-remove" string="Remove Invoice" type="object" attrs="{'invisible': [('l10n_nl_vat_statement_include', '!=', True)]}"/>
+                                </tree>
+                            </field>
                         </page>
                     </notebook>
                 </sheet>

--- a/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.py
+++ b/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.py
@@ -6,6 +6,7 @@ from odoo import api, fields, models
 
 class VatStatementConfigWizard(models.TransientModel):
     _name = 'l10n.nl.vat.statement.config.wizard'
+    _description = 'Netherlands Vat Statement Configuration Wizard'
 
     tag_1a_omzet = fields.Many2one('account.account.tag')
     tag_1a_btw = fields.Many2one('account.account.tag')

--- a/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.py
+++ b/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.py
@@ -26,7 +26,6 @@ class VatStatementConfigWizard(models.TransientModel):
     tag_4b_omzet = fields.Many2one('account.account.tag')
     tag_4b_btw = fields.Many2one('account.account.tag')
     tag_5b_btw = fields.Many2one('account.account.tag')
-    tag_5b_btw_bis = fields.Many2one('account.account.tag')
 
     @api.model
     def default_get(self, fields_list):
@@ -56,7 +55,6 @@ class VatStatementConfigWizard(models.TransientModel):
             defv.setdefault('tag_4b_omzet', config.tag_4b_omzet.id)
             defv.setdefault('tag_4b_btw', config.tag_4b_btw.id)
             defv.setdefault('tag_5b_btw', config.tag_5b_btw.id)
-            defv.setdefault('tag_5b_btw_bis', config.tag_5b_btw_bis.id)
             return defv
 
         is_l10n_nl_coa = self.env.ref('l10n_nl.l10nnl_chart_template', False)
@@ -83,7 +81,6 @@ class VatStatementConfigWizard(models.TransientModel):
         defv.setdefault('tag_4b_omzet', self.env.ref('l10n_nl.tag_nl_17').id)
         defv.setdefault('tag_4b_btw', self.env.ref('l10n_nl.tag_nl_30').id)
         defv.setdefault('tag_5b_btw', self.env.ref('l10n_nl.tag_nl_33').id)
-        defv.setdefault('tag_5b_btw_bis', self.env.ref('l10n_nl.tag_nl_34').id)
         return defv
 
     @api.multi
@@ -119,7 +116,6 @@ class VatStatementConfigWizard(models.TransientModel):
             'tag_4b_omzet': self.tag_4b_omzet.id,
             'tag_4b_btw': self.tag_4b_btw.id,
             'tag_5b_btw': self.tag_5b_btw.id,
-            'tag_5b_btw_bis': self.tag_5b_btw_bis.id,
         })
 
         action_name = 'l10n_nl_tax_statement.action_account_vat_statement_nl'

--- a/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.py
+++ b/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.py
@@ -20,6 +20,7 @@ class VatStatementConfigWizard(models.TransientModel):
     tag_2a_btw = fields.Many2one('account.account.tag')
     tag_3a_omzet = fields.Many2one('account.account.tag')
     tag_3b_omzet = fields.Many2one('account.account.tag')
+    tag_3b_omzet_d = fields.Many2one('account.account.tag')
     tag_3c_omzet = fields.Many2one('account.account.tag')
     tag_4a_omzet = fields.Many2one('account.account.tag')
     tag_4a_btw = fields.Many2one('account.account.tag')
@@ -49,6 +50,7 @@ class VatStatementConfigWizard(models.TransientModel):
             defv.setdefault('tag_2a_btw', config.tag_2a_btw.id)
             defv.setdefault('tag_3a_omzet', config.tag_3a_omzet.id)
             defv.setdefault('tag_3b_omzet', config.tag_3b_omzet.id)
+            defv.setdefault('tag_3b_omzet_d', config.tag_3b_omzet_d.id)
             defv.setdefault('tag_3c_omzet', config.tag_3c_omzet.id)
             defv.setdefault('tag_4a_omzet', config.tag_4a_omzet.id)
             defv.setdefault('tag_4a_btw', config.tag_4a_btw.id)
@@ -110,6 +112,7 @@ class VatStatementConfigWizard(models.TransientModel):
             'tag_2a_btw': self.tag_2a_btw.id,
             'tag_3a_omzet': self.tag_3a_omzet.id,
             'tag_3b_omzet': self.tag_3b_omzet.id,
+            'tag_3b_omzet_d': self.tag_3b_omzet_d.id,
             'tag_3c_omzet': self.tag_3c_omzet.id,
             'tag_4a_omzet': self.tag_4a_omzet.id,
             'tag_4a_btw': self.tag_4a_btw.id,

--- a/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.xml
+++ b/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.xml
@@ -87,10 +87,6 @@
                     <div>
                         <field name="tag_5b_btw" class="oe_inline" placeholder="BTW"/>
                     </div>
-                    <label for="id" string="5b bis"/>
-                    <div>
-                        <field name="tag_5b_btw_bis" class="oe_inline" placeholder="BTW"/>
-                    </div>
                 </group>
             </form>
         </field>

--- a/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.xml
+++ b/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.xml
@@ -57,9 +57,14 @@
                         <field name="tag_3a_omzet" class="oe_inline" placeholder="Omzet"/>
                         <span style="margin-right:5px;"></span>
                     </div>
-                    <label for="id" string="3b"/>
+                    <label for="id" string="3b Leveringen"/>
                     <div>
-                        <field name="tag_3b_omzet" class="oe_inline" placeholder="Omzet"/>
+                        <field name="tag_3b_omzet" class="oe_inline" placeholder="Omzet product"/>
+                        <span style="margin-right:5px;"></span>
+                    </div>
+                    <label for="id" string="3b Diensten"/>
+                    <div>
+                        <field name="tag_3b_omzet_d" class="oe_inline" placeholder="Omzet service"/>
                         <span style="margin-right:5px;"></span>
                     </div>
                     <label for="id" string="3c"/>


### PR DESCRIPTION
This is a proposal to manage past undeclared invoices in module in `l10n_nl_tax_statement`. It was part of the roadmap for this module.

With this PR:

- [x] a new status of the statement is available: 'final'; when a statement is final, it cannot be changed anymore (not even set back to draft)
- [x] you can display past undeclared invoices from a certain initial date (by default is 3 months)
- [x]  recompute the statement lines including the past undeclared invoices
- [x]  tag *5b BTW bis* removed after https://github.com/odoo/odoo/commit/375bff66190cb84d88b9d398e6d4547a89feb2dd
- [x] add support for tag *3b omzet diensten* (see also https://github.com/odoo/odoo/commit/02ccb58401a45528adb77c768318c9f6dfdf05b6)

This is a functional addition to the *Factuurstelsel* system for the Dutch accounting; it is not required to install module `l10n_nl_tax_invoice_basis`, but this new functionality is part of the *Factuurstelsel* requirements, so it's recommended to install `l10n_nl_tax_invoice_basis`.
