### PR TITLE
XmlAuditfileFinancieel syntax fix

### DIFF
--- a/l10n_nl_xaf_auditfile_export/data/XmlAuditfileFinancieel3.2.xsd
+++ b/l10n_nl_xaf_auditfile_export/data/XmlAuditfileFinancieel3.2.xsd
@@ -822,7 +822,7 @@
 			<xsd:enumeration value="QA"/>
 			<xsd:enumeration value="RE"/>
 			<xsd:enumeration value="RO"/>
-+			<xsd:enumeration value="RS"/>
+			<xsd:enumeration value="RS"/>
 			<xsd:enumeration value="RU"/>
 			<xsd:enumeration value="RW"/>
 			<xsd:enumeration value="SA"/>

--- a/l10n_nl_xaf_auditfile_export/data/XmlAuditfileFinancieel3.2.xsd
+++ b/l10n_nl_xaf_auditfile_export/data/XmlAuditfileFinancieel3.2.xsd
@@ -746,6 +746,7 @@
 			<xsd:enumeration value="IR"/>
 			<xsd:enumeration value="IS"/>
 			<xsd:enumeration value="IT"/>
+			<xsd:enumeration value="JE"/>
 			<xsd:enumeration value="JM"/>
 			<xsd:enumeration value="JO"/>
 			<xsd:enumeration value="JP"/>

--- a/l10n_nl_xaf_auditfile_export/views/templates.xml
+++ b/l10n_nl_xaf_auditfile_export/views/templates.xml
@@ -148,7 +148,7 @@
                         <docRef><t t-esc="l.ref" t-esc-options='{"widget": "auditfile.string999"}' /></docRef>
                         <effDate><t t-esc="l.date" /></effDate>
                         <desc><t t-esc="l.name" /></desc>
-                        <amnt><t t-esc="l.credit or l.debit" /></amnt>
+                        <amnt><t t-esc="abs(l.balance)" /></amnt>
                         <amntTp><t t-esc="'C' if l.credit else 'D'" /></amntTp>
                         <recRef t-if="l.full_reconcile_id"><t t-esc="l.full_reconcile_id.name" /></recRef>
                         <custSupID t-if="l.partner_id"><t t-esc="l.partner_id.id" /></custSupID>


### PR DESCRIPTION
Some leftover + from git merging was in the file which resulted in
validation errors.