### PR TITLE
[10.0][FIX] l10n_nl_account_tax_unece: auto_install

### DIFF
--- a/l10n_nl_account_tax_unece/__manifest__.py
+++ b/l10n_nl_account_tax_unece/__manifest__.py
@@ -16,5 +16,5 @@
     ],
     'post_init_hook': 'set_unece_on_taxes',
     'installable': True,
-    'auto_installable': True,
+    'auto_install': True,
 }

--- a/l10n_nl_account_tax_unece/tests/test_nl_account_tax_unece.py
+++ b/l10n_nl_account_tax_unece/tests/test_nl_account_tax_unece.py
@@ -2,9 +2,11 @@
 # Copyright 2017 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase, at_install, post_install
 
 
+@at_install(False)
+@post_install(True)
 class TestNlAccountTaxUnece(TransactionCase):
 
     def setUp(self):


### PR DESCRIPTION
Fixes `'auto_install'` in manifest of `10n_nl_account_tax_unece`.