### PR TITLE
[10.0][FIX] l10n_nl_intrastat: uom_id in tests

### DIFF
--- a/l10n_nl_intrastat/tests/test_all.py
+++ b/l10n_nl_intrastat/tests/test_all.py
@@ -133,7 +133,7 @@ class TestIntrastatNL(TransactionCase):
                     'price_unit': 50.0,
                     'product_id': service.id,
                     'quantity': 5.0,
-                    'uos_id': self.env.ref('product.product_uom_unit').id
+                    'uom_id': self.env.ref('product.product_uom_unit').id
                 }),
                 (0, False, {
                     'name': 'Sale of consumable',
@@ -142,7 +142,7 @@ class TestIntrastatNL(TransactionCase):
                     'price_unit': 35.0,
                     'product_id': consumable.id,
                     'quantity': 1.0,
-                    'uos_id': self.env.ref('product.product_uom_unit').id
+                    'uom_id': self.env.ref('product.product_uom_unit').id
                 }),
                 (0, False, {
                     'name': 'Sale to be excluded from intrastat report',
@@ -151,7 +151,7 @@ class TestIntrastatNL(TransactionCase):
                     'price_unit': 20.0,
                     'product_id': service.id,
                     'quantity': 2.0,
-                    'uos_id': self.env.ref('product.product_uom_unit').id
+                    'uom_id': self.env.ref('product.product_uom_unit').id
                 }),
             ]
         })
@@ -198,7 +198,7 @@ class TestIntrastatNL(TransactionCase):
                     'price_unit': 100.0,
                     'product_id': service.id,
                     'quantity': 1.0,
-                    'uos_id': self.env.ref('product.product_uom_unit').id
+                    'uom_id': self.env.ref('product.product_uom_unit').id
                 }),
             ]
         })


### PR DESCRIPTION
In standard Odoo V10, compared to standard Odoo V9, the technical name of "Unit of Measure" field of the invoice line was renamed from `uos_id` to `uom_id`:

```
    uom_id = fields.Many2one('product.uom', string='Unit of Measure',
        ondelete='set null', index=True, oldname='uos_id')
```

The tests of `l10n_nl_intrastat` are actually raising a warning:
```
2018-02-03 13:32:28,843 5451 INFO openerp_test odoo.addons.l10n_nl_intrastat.tests.test_all: test_generate_report (odoo.addons.l10n_nl_intrastat.tests.test_all.TestIntrastatNL)
2018-02-03 13:32:29,274 5451 WARNING openerp_test odoo.models: account.invoice.line.create() includes unknown fields: uos_id
```


This PR fixes the tests of `l10n_nl_intrastat` accordingly.



