### PR TITLE
[11.0][ADD] l10n_nl_tax_statement_icp

### DIFF
--- a/l10n_nl_cbs_export/models/cbs_export_file.py
+++ b/l10n_nl_cbs_export/models/cbs_export_file.py
@@ -179,7 +179,7 @@ class CbsExportFile(models.Model):
     def _format_header(self):
         company = self.company_id
         month_period = datetime.now().replace(
-            month=int(self.month), year=int(self.year))
+            month=int(self.month), year=int(self.year), day=1)
 
         cbs_export_data = \
             str('9801') + \

--- a/l10n_nl_tax_statement_icp/README.rst
+++ b/l10n_nl_tax_statement_icp/README.rst
@@ -1,0 +1,89 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=========================
+Netherlands ICP Statement
+=========================
+
+This module extends the *Netherlands BTW Statement* module (BTW aangifte report), by adding the statement for the *Intra-Community transactions declaration* (ICP declaration).
+
+The ICP declaration report is based on line *3b - Leveringen naar landen binnen de EU (omzet)* of the BTW aangifte report.
+The period is also the same as the one selected in the BTW aangifte report.
+
+This ICP declaration report includes:
+
+* the VAT identification numbers of your customers;
+* the total amount of intra-Community supplies from the Netherlands for every customer during the selected period.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Install module *l10n_nl_tax_statement* version >= *11.0.2.0.0*.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Follow the configuration steps as described in *l10n_nl_tax_statement* and set the tag *3b omzet* needed for this report.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Create a BTW Statement.
+#. Post the BTW Statement: a new tab *ICP Statement* will be displayed; the tab contains the lines of the ICP declaration report.
+#. In tab *ICP Statement* press the Update button in order to recompute the ICP statement lines.
+
+Printing a PDF report:
+
+#. If you need to print the report in PDF, open a statement form and click: `Print -> NL ICP Statement`
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/176/11.0
+
+
+Known issues / Roadmap
+======================
+
+* Add checks to avoid errors in the report, e.g. no country, wrong country, no VAT code, tax-code not matching fiscal position, etc..
+* Add unit tests
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/l10n-netherlands/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Andrea Stirpe <a.stirpe@onestein.nl>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/l10n_nl_tax_statement_icp/__init__.py
+++ b/l10n_nl_tax_statement_icp/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_nl_tax_statement_icp/__manifest__.py
+++ b/l10n_nl_tax_statement_icp/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Netherlands ICP Statement',
+    'version': '11.0.1.0.0',
+    'category': 'Localization',
+    'license': 'AGPL-3',
+    'author': 'Onestein, Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/l10n-netherlands',
+    'depends': [
+        'l10n_nl_tax_statement',
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/l10n_nl_vat_statement_view.xml',
+        'views/report_tax_statement.xml',
+        'report/report_tax_statement.xml',
+    ],
+    'installable': True,
+}

--- a/l10n_nl_tax_statement_icp/models/__init__.py
+++ b/l10n_nl_tax_statement_icp/models/__init__.py
@@ -1,0 +1,2 @@
+from . import l10n_nl_vat_statement
+from . import l10n_nl_vat_statement_icp_line

--- a/l10n_nl_tax_statement_icp/models/l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement_icp/models/l10n_nl_vat_statement.py
@@ -1,0 +1,201 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class VatStatement(models.Model):
+    _inherit = 'l10n.nl.vat.statement'
+
+    tag_3b_omzet = fields.Many2one(
+        'account.account.tag',
+        compute='_compute_tag_3b_omzet'
+    )
+    tag_3b_omzet_d = fields.Many2one(
+        'account.account.tag',
+        compute='_compute_tag_3b_omzet'
+    )
+    icp_line_ids = fields.One2many(
+        'l10n.nl.vat.statement.icp.line',
+        'statement_id',
+        string='ICP Lines',
+        readonly=True
+    )
+    icp_total = fields.Monetary(
+        string='Total ICP amount',
+        readonly=True,
+        help='Total amount in currency of the statement.'
+    )
+
+    @api.depends('company_id')
+    def _compute_tag_3b_omzet(self):
+        ''' Computes Tag 3b omzet'''
+        for statement in self:
+            config = self.env['l10n.nl.vat.statement.config'].search([
+                ('company_id', '=', statement.company_id.id)
+            ], limit=1)
+            statement.tag_3b_omzet = config.tag_3b_omzet
+            statement.tag_3b_omzet_d = config.tag_3b_omzet_d
+
+    @api.multi
+    def _compute_icp_lines(self):
+        ''' Computes ICP lines for the report'''
+        IcpLine = self.env['l10n.nl.vat.statement.icp.line']
+        for statement in self:
+            statement.icp_line_ids.unlink()
+            statement.icp_total = 0.0
+            amounts_map = statement._get_partner_amounts_map()
+            for partner_id in amounts_map:
+                icp_values = self._prepare_icp_line(amounts_map[partner_id])
+                icp_values['partner_id'] = partner_id
+                icp_values['statement_id'] = statement.id
+                newline = IcpLine.create(icp_values)
+                statement.icp_line_ids += newline
+                icp_total = newline.amount_products + newline.amount_services
+                statement.icp_total += icp_total
+
+    @api.model
+    def _prepare_icp_line(self, partner_amounts):
+        ''' Prepares an internal data structure representing the ICP line'''
+        return {
+            'country_code': partner_amounts['country_code'],
+            'vat': partner_amounts['vat'],
+            'amount_products': partner_amounts['amount_products'],
+            'amount_services': partner_amounts['amount_services'],
+            'currency_id': partner_amounts['currency_id'],
+        }
+
+    @api.multi
+    def _is_3b_omzet_line(self, line):
+        self.ensure_one()
+
+        tag_3b_omzet = self.tag_3b_omzet
+        for tax in line.tax_ids:
+            if tax.tag_ids.filtered(
+                    lambda r: r == tag_3b_omzet):
+                return True
+        return False
+
+    @api.multi
+    def _is_3b_omzet_diensten_line(self, line):
+        self.ensure_one()
+
+        tag_3b_omzet_d = self.tag_3b_omzet_d
+        for tax in line.tax_ids:
+            if tax.tag_ids.filtered(
+                    lambda r: r == tag_3b_omzet_d):
+                return True
+        return False
+
+    @api.multi
+    def _get_partner_amounts_map(self):
+        ''' Generate an internal data structure representing the ICP line'''
+        self.ensure_one()
+
+        partner_amounts_map = {}
+        for line in self.move_line_ids:
+            is_3b_omzet = self._is_3b_omzet_line(line)
+            is_3b_omzet_diensten = self._is_3b_omzet_diensten_line(line)
+            if is_3b_omzet or is_3b_omzet_diensten:
+                vals = self._prepare_icp_line_from_move_line(line)
+                if vals['partner_id'] not in partner_amounts_map:
+                    self._init_partner_amounts_map(partner_amounts_map, vals)
+                self._update_partner_amounts_map(partner_amounts_map, vals)
+        return partner_amounts_map
+
+    @api.multi
+    def _check_config_tag_3b_omzet(self):
+        ''' Checks the tag 3b Omzet, as configured for the BTW statement'''
+        if self.env.context.get('skip_check_config_tag_3b_omzet'):
+            return
+        for statement in self:
+            if not statement.tag_3b_omzet or not statement.tag_3b_omzet_d:
+                raise UserError(
+                    _('Tag 3b omzet not configured for this Company! '
+                      'Check the NL BTW Tags Configuration.'))
+
+    @classmethod
+    def _update_partner_amounts_map(cls, partner_amounts_map, vals):
+        ''' Update amounts of the internal ICP lines data structure'''
+        map_data = partner_amounts_map[vals['partner_id']]
+        map_data['amount_products'] += vals['amount_products']
+        map_data['amount_services'] += vals['amount_services']
+
+    @classmethod
+    def _init_partner_amounts_map(cls, partner_amounts_map, vals):
+        ''' Initialize the internal ICP lines data structure'''
+        partner_amounts_map[vals['partner_id']] = {
+            'country_code': vals['country_code'],
+            'vat': vals['vat'],
+            'currency_id': vals['currency_id'],
+            'amount_products': 0.0,
+            'amount_services': 0.0,
+        }
+
+    @api.multi
+    def _prepare_icp_line_from_move_line(self, line):
+        ''' Gets move line details and prepares ICP report line data'''
+        self.ensure_one()
+
+        balance = line.balance
+        if line.company_currency_id != self.currency_id:
+            balance = line.company_currency_id.with_context(
+                date=line.date
+            ).compute(balance, self.currency_id, round=True)
+        amount_products = balance
+        amount_services = 0.0
+        if self._is_3b_omzet_diensten_line(line):
+            amount_products = 0.0
+            amount_services = balance
+
+        return {
+            'partner_id': line.partner_id.id,
+            'country_code': line.partner_id.country_id.code,
+            'vat': line.partner_id.vat,
+            'amount_products': amount_products,
+            'amount_services': amount_services,
+            'currency_id': self.currency_id.id,
+        }
+
+    @api.multi
+    def reset(self):
+        ''' Removes ICP lines if reset to draft'''
+        for statement in self:
+            statement.icp_line_ids.unlink()
+        return super(VatStatement, self).reset()
+
+    @api.multi
+    def post(self):
+        ''' Checks configuration when validating the statement'''
+        self.ensure_one()
+        self._check_config_tag_3b_omzet()
+        res = super(VatStatement, self).post()
+        self._compute_icp_lines()
+        return res
+
+    @api.model
+    def _modifiable_values_when_posted(self):
+        ''' Returns the modifiable fields even when the statement is posted'''
+        res = super(VatStatement, self)._modifiable_values_when_posted()
+        res.append('icp_line_ids')
+        res.append('icp_total')
+        return res
+
+    @api.multi
+    def icp_update(self):
+        ''' Update button'''
+        self.ensure_one()
+
+        if self.state in ['final']:
+            raise UserError(
+                _('You cannot modify a final statement!'))
+
+        # clean old lines
+        self.icp_line_ids.unlink()
+
+        # check config
+        self._check_config_tag_3b_omzet()
+
+        # create lines
+        self._compute_icp_lines()

--- a/l10n_nl_tax_statement_icp/models/l10n_nl_vat_statement_icp_line.py
+++ b/l10n_nl_tax_statement_icp/models/l10n_nl_vat_statement_icp_line.py
@@ -1,0 +1,63 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, api, fields, models
+from odoo.tools.misc import formatLang
+from odoo.exceptions import ValidationError
+
+
+class VatStatementIcpLine(models.Model):
+    _name = 'l10n.nl.vat.statement.icp.line'
+    _description = 'Intra-Community transactions (ICP) line'
+    _order = 'partner_id, country_code'
+
+    statement_id = fields.Many2one(
+        'l10n.nl.vat.statement',
+        'Statement',
+        ondelete='cascade'
+    )
+    partner_id = fields.Many2one(
+        'res.partner',
+        string='Partner',
+        readonly=True,
+        required=True,
+    )
+    vat = fields.Char(
+        string='VAT',
+        readonly=True,
+    )
+    country_code = fields.Char(
+        readonly=True,
+    )
+    currency_id = fields.Many2one(
+        'res.currency',
+        string='Currency',
+        readonly=True
+    )
+    amount_products = fields.Monetary(readonly=True)
+    format_amount_products = fields.Char(compute='_compute_icp_amount_format')
+    amount_services = fields.Monetary(readonly=True)
+    format_amount_services = fields.Char(compute='_compute_icp_amount_format')
+
+    @api.depends('amount_products', 'amount_services')
+    def _compute_icp_amount_format(self):
+        for line in self:
+            amount_products = formatLang(
+                self.env, line.amount_products, monetary=True)
+            amount_services = formatLang(
+                self.env, line.amount_services, monetary=True)
+            line.format_amount_products = amount_products
+            line.format_amount_services = amount_services
+
+    @api.constrains('country_code')
+    def _check_country_code(self):
+        country_codes = self.mapped('country_code')
+        if self.env.ref('base.nl').code in country_codes:
+            raise ValidationError(_(
+                'Wrong country code (NL) for ICP report.'))
+        europe_codes = self.env.ref('base.europe').country_ids.mapped('code')
+        for code in country_codes:
+            if code not in europe_codes:
+                raise ValidationError(_(
+                    'Wrong country code (%s) for ICP report. '
+                    'Please check your configuration.') % code)

--- a/l10n_nl_tax_statement_icp/readme/CONFIGURE.rst
+++ b/l10n_nl_tax_statement_icp/readme/CONFIGURE.rst
@@ -1,0 +1,3 @@
+To configure this module, you need to:
+
+#. Follow the configuration steps as described in *l10n_nl_tax_statement* and set the tag *3b omzet* needed for this report.

--- a/l10n_nl_tax_statement_icp/readme/CONTRIBUTORS.rst
+++ b/l10n_nl_tax_statement_icp/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Andrea Stirpe <a.stirpe@onestein.nl>

--- a/l10n_nl_tax_statement_icp/readme/DESCRIPTION.rst
+++ b/l10n_nl_tax_statement_icp/readme/DESCRIPTION.rst
@@ -1,0 +1,9 @@
+This module extends the *Netherlands BTW Statement* module (BTW aangifte report), by adding the statement for the *Intra-Community transactions declaration* (ICP declaration).
+
+The ICP declaration report is based on line *3b - Leveringen naar landen binnen de EU (omzet)* of the BTW aangifte report.
+The period is also the same as the one selected in the BTW aangifte report.
+
+This ICP declaration report includes:
+
+* the VAT identification numbers of your customers;
+* the total amount of intra-Community supplies from the Netherlands for every customer during the selected period.

--- a/l10n_nl_tax_statement_icp/readme/INSTALL.rst
+++ b/l10n_nl_tax_statement_icp/readme/INSTALL.rst
@@ -1,0 +1,3 @@
+To install this module, you need to:
+
+#. Install module *l10n_nl_tax_statement* version >= *11.0.2.0.0*.

--- a/l10n_nl_tax_statement_icp/readme/ROADMAP.rst
+++ b/l10n_nl_tax_statement_icp/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+* Add checks to avoid errors in the report, e.g. no VAT code, tax-code not matching fiscal position, etc..

--- a/l10n_nl_tax_statement_icp/readme/USAGE.rst
+++ b/l10n_nl_tax_statement_icp/readme/USAGE.rst
@@ -1,0 +1,9 @@
+To use this module, you need to:
+
+#. Create a BTW Statement.
+#. Post the BTW Statement: a new tab *ICP Statement* will be displayed; the tab contains the lines of the ICP declaration report.
+#. In tab *ICP Statement* press the Update button in order to recompute the ICP statement lines.
+
+Printing a PDF report:
+
+#. If you need to print the report in PDF, open a statement form and click: `Print -> NL ICP Statement`

--- a/l10n_nl_tax_statement_icp/report/report_tax_statement.xml
+++ b/l10n_nl_tax_statement_icp/report/report_tax_statement.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Onestein (<http://www.onestein.eu>)
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <template id="l10n_nl_tax_statement_icp.report_tax_statement_icp">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-call="web.internal_layout">
+                    <!-- Defines global variables used by internal layout -->
+                    <t t-set="title">ICP</t>
+                    <t t-set="company_name" t-value="o.company_id.name"/>
+
+                    <div class="page nl_tax">
+                        <!-- Display filters -->
+                        <t t-call="l10n_nl_tax_statement.report_tax_statement_filters"/>
+
+                        <div>
+                            <br/><br/><br/><br/>
+                        </div>
+
+                        <!-- Top header -->
+                        <div class="nl_tax_act_as_table nl_tax_table" style="width: 1140px;">
+                            <div class="nl_tax_act_as_row labels">
+                                <div class="nl_tax_act_as_cell left">Partner</div>
+                                <div class="nl_tax_act_as_cell left">VAT</div>
+                                <div class="nl_tax_act_as_cell left">Country Code</div>
+                                <div class="nl_tax_act_as_cell right">Currency</div>
+                                <div class="nl_tax_act_as_cell right">Amount Product</div>
+                                <div class="nl_tax_act_as_cell right">Amount Service</div>
+                            </div>
+                            <!-- Display lines -->
+                            <t t-foreach="o.icp_line_ids" t-as="line">
+                                <div class="nl_tax_act_as_row lines">
+                                    <div class="nl_tax_act_as_cell left"><span t-field="line.partner_id"/></div>
+                                    <div class="nl_tax_act_as_cell left"><span t-field="line.vat"/></div>
+                                    <div class="nl_tax_act_as_cell left"><span t-field="line.country_code"/></div>
+                                    <div class="nl_tax_act_as_cell right"><span t-field="line.currency_id"/></div>
+                                    <div class="nl_tax_act_as_cell right"><span t-field="line.format_amount_products"/></div>
+                                    <div class="nl_tax_act_as_cell right"><span t-field="line.format_amount_services"/></div>
+                                </div>
+                            </t>
+                            <div class="nl_tax_act_as_row labels">
+                                <!--## total amount-->
+                                <div class="nl_tax_act_as_cell left"> </div>
+                                <div class="nl_tax_act_as_cell left"> </div>
+                                <div class="nl_tax_act_as_cell left"> </div>
+                                <div class="nl_tax_act_as_cell right">Total amount</div>
+                                <div class="nl_tax_act_as_cell right">(product + service)</div>
+                                <div class="nl_tax_act_as_cell right"><span t-field="o.icp_total"/></div>
+                            </div>
+                        </div>
+                    </div>
+                </t>
+            </t>
+        </t>
+    </template>
+
+</odoo>

--- a/l10n_nl_tax_statement_icp/security/ir.model.access.csv
+++ b/l10n_nl_tax_statement_icp/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_l10n_nl_vat_statement_icp_line,access_l10n_nl_vat_statement_icp_line,model_l10n_nl_vat_statement_icp_line,account.group_account_user,1,1,1,1

--- a/l10n_nl_tax_statement_icp/tests/__init__.py
+++ b/l10n_nl_tax_statement_icp/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_l10n_nl_tax_statement_icp

--- a/l10n_nl_tax_statement_icp/tests/test_l10n_nl_tax_statement_icp.py
+++ b/l10n_nl_tax_statement_icp/tests/test_l10n_nl_tax_statement_icp.py
@@ -1,0 +1,139 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.exceptions import UserError, ValidationError
+
+from odoo.addons.l10n_nl_tax_statement.tests.test_l10n_nl_vat_statement\
+    import TestVatStatement
+
+
+class TestTaxStatementIcp(TestVatStatement):
+
+    def _prepare_icp_invoice(self):
+        for invoice_line in self.invoice_1.invoice_line_ids:
+            for tax_line in invoice_line.invoice_line_tax_ids:
+                tax_line.tag_ids = self.tag_3
+        self.invoice_1._onchange_invoice_line_ids()
+        self.invoice_1.action_invoice_open()
+        self.statement_with_icp.statement_update()
+
+    def test_01_compute_tag_3b_omzet(self):
+        self.statement_with_icp = self.env['l10n.nl.vat.statement'].create({
+            'name': 'Statement 1',
+        })
+
+        self.assertEqual(self.statement_with_icp.tag_3b_omzet, self.tag_3)
+        self.assertEqual(self.statement_with_icp.tag_3b_omzet_d, self.tag_4)
+
+    def test_02_no_tag_3b_omzet(self):
+        self.config.write({
+            'tag_3b_omzet': False,
+            'tag_3b_omzet_d': False,
+        })
+        self.statement_not_valid = self.env['l10n.nl.vat.statement'].create({
+            'name': 'Statement 1',
+        })
+        self.statement_not_valid.statement_update()
+        with self.assertRaises(UserError):
+            self.statement_not_valid.post()
+
+    def test_03_post_final(self):
+        self.statement_with_icp = self.env['l10n.nl.vat.statement'].create({
+            'name': 'Statement 1',
+        })
+
+        # all previous statements must be already posted
+        self.statement_with_icp.statement_update()
+        with self.assertRaises(UserError):
+            self.statement_with_icp.post()
+
+        self.statement_1.statement_update()
+        self.statement_1.post()
+        self.assertEqual(self.statement_1.state, 'posted')
+
+        # first post
+        self.statement_with_icp.post()
+
+        self.assertEqual(self.statement_with_icp.state, 'posted')
+        self.assertTrue(self.statement_with_icp.date_posted)
+
+        self.statement_with_icp.icp_update()
+
+        # then finalize
+        self.statement_with_icp.finalize()
+        self.assertEqual(self.statement_with_icp.state, 'final')
+        self.assertTrue(self.statement_with_icp.date_posted)
+
+        with self.assertRaises(UserError):
+            self.statement_with_icp.icp_update()
+
+    def test_04_icp_invoice(self):
+        self.statement_1.post()
+        self.statement_with_icp = self.env['l10n.nl.vat.statement'].create({
+            'name': 'Statement 1',
+        })
+
+        self.invoice_1.partner_id.country_id = self.env.ref('base.be')
+        self._prepare_icp_invoice()
+
+        self.statement_with_icp.post()
+        self.assertTrue(self.statement_with_icp.icp_line_ids)
+        self.assertTrue(self.statement_with_icp.icp_total)
+
+        for icp_line in self.statement_with_icp.icp_line_ids:
+            self.assertTrue(icp_line.amount_products)
+            self.assertFalse(icp_line.amount_services)
+            amount_products = icp_line.format_amount_products
+            self.assertEqual(float(amount_products), icp_line.amount_products)
+            amount_services = icp_line.format_amount_services
+            self.assertEqual(float(amount_services), icp_line.amount_services)
+
+    def test_05_icp_invoice_service(self):
+        self.statement_1.post()
+        self.statement_with_icp = self.env['l10n.nl.vat.statement'].create({
+            'name': 'Statement 1',
+        })
+
+        self.invoice_1.partner_id.country_id = self.env.ref('base.be')
+        for invoice_line in self.invoice_1.invoice_line_ids:
+            for tax_line in invoice_line.invoice_line_tax_ids:
+                tax_line.tag_ids = self.tag_4
+        self.invoice_1._onchange_invoice_line_ids()
+        self.invoice_1.action_invoice_open()
+        self.statement_with_icp.statement_update()
+
+        self.statement_with_icp.post()
+        self.assertTrue(self.statement_with_icp.icp_line_ids)
+        self.assertTrue(self.statement_with_icp.icp_total)
+
+        for icp_line in self.statement_with_icp.icp_line_ids:
+            self.assertFalse(icp_line.amount_products)
+            self.assertTrue(icp_line.amount_services)
+            amount_products = icp_line.format_amount_products
+            self.assertEqual(float(amount_products), icp_line.amount_products)
+            amount_services = icp_line.format_amount_services
+            self.assertEqual(float(amount_services), icp_line.amount_services)
+
+    def test_06_icp_invoice_nl(self):
+        self.statement_1.post()
+        self.statement_with_icp = self.env['l10n.nl.vat.statement'].create({
+            'name': 'Statement 1',
+        })
+
+        self.invoice_1.partner_id.country_id = self.env.ref('base.nl')
+        self._prepare_icp_invoice()
+
+        with self.assertRaises(ValidationError):
+            self.statement_with_icp.post()
+
+    def test_07_icp_invoice_outside_europe(self):
+        self.statement_1.post()
+        self.statement_with_icp = self.env['l10n.nl.vat.statement'].create({
+            'name': 'Statement 1',
+        })
+
+        self.invoice_1.partner_id.country_id = self.env.ref('base.us')
+        self._prepare_icp_invoice()
+
+        with self.assertRaises(ValidationError):
+            self.statement_with_icp.post()

--- a/l10n_nl_tax_statement_icp/views/l10n_nl_vat_statement_view.xml
+++ b/l10n_nl_tax_statement_icp/views/l10n_nl_vat_statement_view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Onestein (<http://www.onestein.eu>)
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record id="view_l10n_nl_vat_report_form" model="ir.ui.view">
+        <field name="model">l10n.nl.vat.statement</field>
+        <field name="inherit_id" ref="l10n_nl_tax_statement.view_l10n_nl_vat_report_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page name="icp_statement" string="ICP Statement" attrs="{'invisible':[('state','=','draft')]}">
+                    <group name="icp_lines" string="ICP Statement lines">
+                        <div states="posted">Press the Update button in order to recompute the lines!</div>
+                        <div class="oe_button_box" name="button_box">
+                            <button name="icp_update" string="Update" states="posted" type="object" class="oe_stat_button" icon="fa-repeat"/>
+                        </div>
+                    </group>
+                    <field name="icp_line_ids">
+                        <tree editable="bottom" create="false" delete="false">
+                            <field name="partner_id" />
+                            <field name="vat" />
+                            <field name="country_code" />
+                            <field name="currency_id" />
+                            <field name="amount_products" />
+                            <field name="amount_services" />
+                        </tree>
+                    </field>
+                    <group>
+                        <group>
+                        </group>
+                        <group>
+                            <label for="icp_total"/>
+                            <field name="icp_total" nolabel="1"/>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_nl_tax_statement_icp/views/report_tax_statement.xml
+++ b/l10n_nl_tax_statement_icp/views/report_tax_statement.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Onestein (<http://www.onestein.eu>)
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <report
+      id="action_report_tax_statement_icp"
+      model="l10n.nl.vat.statement"
+      string="NL ICP Statement"
+      report_type="qweb-pdf"
+      name="l10n_nl_tax_statement_icp.report_tax_statement_icp"
+      file="l10n_nl_tax_statement_icp.report_tax_statement_icp"
+      />
+
+    <record id="action_report_tax_statement_icp" model="ir.actions.report">
+        <field name="paperformat_id" ref="l10n_nl_tax_statement.paperformat_nl_tax_statement"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This module extends the `l10n_nl_tax_statement` module, providing a new statement for the *Intra-Community transactions declaration* (ICP declaration).

The new ICP declaration report is based on the tag *3b - Leveringen naar landen binnen de EU (omzet)*, the same as it is already configured for the BTW aangifte report (of module `l10n_nl_tax_statement`). The period is also the same as the one selected in the BTW aangifte report. This way the ICP report and the BTW aangifte report based on the same data, as discussed in https://github.com/OCA/l10n-netherlands/issues/102.

To install this module, you need to be sure that version *11.0.2.0.0* (or later) of module `l10n_nl_tax_statement` is installed.

This module supersedes module `l10n_nl_intrastat`.

The discussion about the redesign/replacement of module `l10n_nl_intrastat` is here: https://github.com/OCA/l10n-netherlands/issues/102

Fixes https://github.com/OCA/l10n-netherlands/issues/102
