### PR TITLE
[FIX] l10n_nl_xaf_auditfile_export: fix issue with decimal precision 2

### DIFF
--- a/l10n_nl_xaf_auditfile_export/views/templates.xml
+++ b/l10n_nl_xaf_auditfile_export/views/templates.xml
@@ -148,7 +148,7 @@
                         <docRef><t t-esc="l.ref" t-esc-options='{"widget": "auditfile.string999"}' /></docRef>
                         <effDate><t t-esc="l.date" /></effDate>
                         <desc><t t-esc="l.name" /></desc>
-                        <amnt><t t-esc="l.credit or l.debit" /></amnt>
+                        <amnt><t t-esc="abs(l.balance)" /></amnt>
                         <amntTp><t t-esc="'C' if l.credit else 'D'" /></amntTp>
                         <recRef t-if="l.full_reconcile_id"><t t-esc="l.full_reconcile_id.name" /></recRef>
                         <custSupID t-if="l.partner_id"><t t-esc="l.partner_id.id" /></custSupID>


### PR DESCRIPTION
This issue was fixed in 9.0 at https://github.com/OCA/l10n-netherlands/commit/ca06a9d01da2772f1e3652e85617b1900735d96b and in 11.0 too, but not in V10. This commit resolves it on 10.0 too.
When the rounding is set to 2 it'll throw tracebacks, as originally reported at https://github.com/OCA/l10n-netherlands/pull/130