### PR TITLE
[FIX] CSS Namespace conflict with account_financial_report_qweb

### DIFF
--- a/l10n_nl_tax_statement/data/report_layouts.xml
+++ b/l10n_nl_tax_statement/data/report_layouts.xml
@@ -8,6 +8,7 @@
     </template>
 
     <template id="l10n_nl_tax_statement.internal_layout">
+        <div class="nl_tax">
         <div class="header">
             <div class="row">
                 <div class="col-xs-6">
@@ -21,11 +22,11 @@
         <t t-raw="0" />
         <div class="footer">
             <div class="row">
-                <div class="col-xs-6 custom_footer">
+                <div class="col-xs-6 nl_tax_footer">
                     <span>Printed: </span>
                     <span t-esc="context_timestamp(datetime.datetime.now()).strftime('%Y-%m-%d %H:%M')"/>
                 </div>
-                <div class="col-xs-6 text-right custom_footer">
+                <div class="col-xs-6 text-right nl_tax_footer">
                     <ul class="list-inline">
                         <li><span class="page"/></li>
                         <li>/</li>
@@ -33,6 +34,7 @@
                     </ul>
                 </div>
             </div>
+        </div>
         </div>
     </template>
 

--- a/l10n_nl_tax_statement/report/report_tax_statement.xml
+++ b/l10n_nl_tax_statement/report/report_tax_statement.xml
@@ -2,29 +2,29 @@
 <odoo>
 
     <template id="l10n_nl_tax_statement.report_tax_statement_filters">
-        <div class="act_as_table data_table" style="width: 1140px;">
-            <div class="act_as_row labels">
-                <div class="act_as_cell">Date range</div>
-                <div class="act_as_cell">Target moves</div>
-                <div class="act_as_cell">Currency</div>
-                <div class="act_as_cell">Date posted</div>
-                <div class="act_as_cell">Date update</div>
+        <div class="nl_tax_act_as_table nl_tax_table" style="width: 1140px;">
+            <div class="nl_tax_act_as_row labels">
+                <div class="nl_tax_act_as_cell">Date range</div>
+                <div class="nl_tax_act_as_cell">Target moves</div>
+                <div class="nl_tax_act_as_cell">Currency</div>
+                <div class="nl_tax_act_as_cell">Date posted</div>
+                <div class="nl_tax_act_as_cell">Date update</div>
             </div>
-            <div class="act_as_row">
-                <div class="act_as_cell">
+            <div class="nl_tax_act_as_row">
+                <div class="nl_tax_act_as_cell">
                     <span t-field="o.from_date"/>
                     <span t-field="o.to_date"/>
                 </div>
-                <div class="act_as_cell">
+                <div class="nl_tax_act_as_cell">
                     <span t-field="o.target_move"/>
                 </div>
-                <div class="act_as_cell">
+                <div class="nl_tax_act_as_cell">
                     <span t-field="o.currency_id"/>
                 </div>
-                <div class="act_as_cell">
+                <div class="nl_tax_act_as_cell">
                     <span t-field="o.date_posted"/>
                 </div>
-                <div class="act_as_cell">
+                <div class="nl_tax_act_as_cell">
                     <span t-field="o.date_update"/>
                 </div>
             </div>
@@ -48,32 +48,32 @@
                         </div>
 
                         <!-- Top header -->
-                        <div class="act_as_table data_table" style="width: 1140px;">
-                            <div class="act_as_row lines">
-                                <div class="act_as_cell left" style="width: 900px;"> </div>
-                                <div class="act_as_cell right">Omzet</div>
-                                <div class="act_as_cell right">BTW</div>
+                        <div class="nl_tax_act_as_table nl_tax_table" style="width: 1140px;">
+                            <div class="nl_tax_act_as_row lines">
+                                <div class="nl_tax_act_as_cell left" style="width: 900px;"> </div>
+                                <div class="nl_tax_act_as_cell right">Omzet</div>
+                                <div class="nl_tax_act_as_cell right">BTW</div>
                             </div>
                             <!-- Display lines -->
                             <t t-foreach="o.line_ids" t-as="line">
-                                <div t-if="line.is_group" class="act_as_row labels">
+                                <div t-if="line.is_group" class="nl_tax_act_as_row labels">
                                     <!--## line header-->
-                                    <div class="act_as_cell left" style="width: 900px;"><span t-field="line.code"/> - <span t-field="line.name"/></div>
-                                    <div class="act_as_cell right"> </div>
-                                    <div class="act_as_cell right"> </div>
+                                    <div class="nl_tax_act_as_cell left" style="width: 900px;"><span t-field="line.code"/> - <span t-field="line.name"/></div>
+                                    <div class="nl_tax_act_as_cell right"> </div>
+                                    <div class="nl_tax_act_as_cell right"> </div>
                                 </div>
-                                <div t-if="not line.is_group" class="act_as_row lines">
+                                <div t-if="not line.is_group" class="nl_tax_act_as_row lines">
                                     <!--## code, description, omzet, btw-->
-                                    <div class="act_as_cell left" style="width: 900px;"> &amp;nbsp; &amp;nbsp; <span t-field="line.code"/> - <span t-field="line.name"/></div>
-                                    <div class="act_as_cell right"><span t-field="line.format_omzet"/></div>
-                                    <div class="act_as_cell right"><span t-field="line.format_btw"/></div>
+                                    <div class="nl_tax_act_as_cell left" style="width: 900px;"> &amp;nbsp; &amp;nbsp; <span t-field="line.code"/> - <span t-field="line.name"/></div>
+                                    <div class="nl_tax_act_as_cell right"><span t-field="line.format_omzet"/></div>
+                                    <div class="nl_tax_act_as_cell right"><span t-field="line.format_btw"/></div>
                                 </div>
                             </t>
-                            <div class="act_as_row lines">
+                            <div class="nl_tax_act_as_row lines">
                                 <!--## total btw-->
-                                <div class="act_as_cell left" style="width: 900px;"> &amp;nbsp; &amp;nbsp; 5g - Totaal</div>
-                                <div class="act_as_cell right"> </div>
-                                <div class="act_as_cell right"><span t-field="o.format_btw_total"/></div>
+                                <div class="nl_tax_act_as_cell left" style="width: 900px;"> &amp;nbsp; &amp;nbsp; 5g - Totaal</div>
+                                <div class="nl_tax_act_as_cell right"> </div>
+                                <div class="nl_tax_act_as_cell right"><span t-field="o.format_btw_total"/></div>
                             </div>
                         </div>
                     </div>

--- a/l10n_nl_tax_statement/static/src/css/report.css
+++ b/l10n_nl_tax_statement/static/src/css/report.css
@@ -1,22 +1,22 @@
-body, table, td, span, div {
+.nl_tax > table, .nl_tax > td, .nl_tax > span, .nl_tax > div {
     font-family: Helvetica, Arial;
 }
-.act_as_table {
+.nl_tax_act_as_table {
     display: table;
 }
-.act_as_row  {
+.nl_tax_act_as_row  {
     display: table-row !important;
     page-break-inside: avoid;
 }
-.act_as_cell {
+.nl_tax_act_as_cell {
     display: table-cell;
     page-break-inside: avoid;
     font-size:18px;
 }
-.act_as_row.labels {
+.nl_tax_act_as_row.labels {
     background-color:#F0F0F0;
 }
-.data_table {
+.nl_tax_table {
     width: 100%;
     table-layout: fixed;
     border-left:0px;
@@ -29,21 +29,21 @@ body, table, td, span, div {
     padding-bottom:3px;
     border-collapse:collapse;
 }
-.data_table .act_as_cell{
+.nl_tax_table .nl_tax_act_as_cell{
     border-bottom: 1px solid lightGrey;
     text-align: center;
     word-wrap: break-word;
 }
-.data_table .act_as_row.labels {
+.nl_tax_table .nl_tax_act_as_row.labels {
     font-weight: bold;
 }
-.act_as_cell.right {
+.nl_tax_act_as_cell.right {
     word-wrap:normal;
     text-align:right;
 }
-.act_as_cell.left {
+.nl_tax_act_as_cell.left {
     text-align:left;
 }
-.custom_footer {
+.nl_tax_footer {
     font-size:18px;
 }


### PR DESCRIPTION
The CSS in this module seems borrowed from https://github.com/OCA/account-financial-reporting/blob/10.0/account_financial_report_qweb/static/src/css/report.css. The styles have diverged by now, so that when both modules are installed the layout is messed up.

![vat](https://user-images.githubusercontent.com/1033124/37056903-03dec42c-2186-11e8-86fe-2267c9227ffb.png)
