### PR TITLE
[RFR] Bump version number

### DIFF
--- a/l10n_nl_tax_statement/__manifest__.py
+++ b/l10n_nl_tax_statement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Netherlands BTW Statement',
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.2.0',
     'category': 'Localization',
     'license': 'AGPL-3',
     'author': 'Onestein, Odoo Community Association (OCA)',


### PR DESCRIPTION
Forgot to include a version bump in https://github.com/OCA/l10n-netherlands/pull/155 even though the module needs to be upgraded with this change.