### PR TITLE
[FIX] force periods in tests

### DIFF
--- a/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
@@ -8,13 +8,25 @@ from openerp.tests.common import TransactionCase
 
 class TestL10nNlXafAuditfileExport(TransactionCase):
 
+    def setUp(self):
+        super(TestL10nNlXafAuditfileExport, self).setUp()
+        self.fiscalyear = self.env['account.fiscalyear'].browse(
+            self.env['account.fiscalyear'].find()
+        )
+        self.export = self.env['xaf.auditfile.export'].create({})
+        # depending on other modules installed, we get some undefined
+        # fiscal year via defaults, force this to the current year
+        # in order to be sure we get account's demo data
+        self.export.write({
+            'period_start': self.fiscalyear.period_ids[0].id,
+            'period_end': self.fiscalyear.period_ids[-1].id,
+        })
+
     def test_l10n_nl_xaf_auditfile_export_default(self):
-        export = self.env['xaf.auditfile.export'].create({})
-        export.button_generate()
-        self.assertTrue(export.auditfile)
+        self.export.button_generate()
+        self.assertTrue(self.export.auditfile)
 
     def test_l10n_nl_xaf_auditfile_export_all(self):
-        export = self.env['xaf.auditfile.export'].create(
-            {'data_export': 'all'})
-        export.button_generate()
-        self.assertTrue(export.auditfile)
+        self.export.write({'data_export': 'all'})
+        self.export.button_generate()
+        self.assertTrue(self.export.auditfile)


### PR DESCRIPTION
the wizard's `default_get` selects the previous fiscal year if it finds any. Now there are a couple of other modules that create fiscal years in the past for testing purposes, which will make the current tests break because then we select this earlier fiscal year, but the demo move lines are created for the current fiscal year. With the filtering introduced by #119, we'll end up without accounts, rendering the xaf invalid and the tests failing.