### PR TITLE
[9.0] [FIX] l10n_nl_xaf_auditfile_export: fix rounding issues

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -236,7 +236,7 @@ class XafAuditfileExport(models.Model):
             'and date <= \'' + self.date_end + '\' '
             'and (company_id=%s or company_id is null)',
             (self.company_id.id, ))
-        return self.env.cr.fetchall()[0][0]
+        return round(self.env.cr.fetchall()[0][0], 2)
 
     @api.multi
     def get_move_line_total_credit(self):
@@ -247,7 +247,7 @@ class XafAuditfileExport(models.Model):
             'and date <= \'' + self.date_end + '\' '
             'and (company_id=%s or company_id is null)',
             (self.company_id.id, ))
-        return self.env.cr.fetchall()[0][0]
+        return round(self.env.cr.fetchall()[0][0], 2)
 
     @api.multi
     def get_journals(self):


### PR DESCRIPTION
Backport of https://github.com/OCA/l10n-netherlands/commit/819b393617c2c3f3e1dd0d1b4d0040bbdc5babb4

Before this fix you will get both an error on the `totalCredit` and `totalDebit` when the result of one of those two has a bigger decimal precision than 2. For an example customer we would get this traceback:
```
:18296:0:ERROR:SCHEMASV:SCHEMAV_CVC_FRACTIONDIGITS_VALID: Element '{http://www.auditfiles.nl/XAF/3.2}totalCredit': [facet 'fractionDigits'] The value '1207618.6192' has more fractional digits than are allowed ('2').

:18296:0:ERROR:SCHEMASV:SCHEMAV_CVC_DATATYPE_VALID_1_2_1: Element '{http://www.auditfiles.nl/XAF/3.2}totalCredit': '1207618.6192' is not a valid value of the atomic type '{http://www.auditfiles.nl/XAF/3.2}Amount2decimals'. 
```

By rounding the returned SQL values we're always sure the precision is 2 and not something like 4.
This fixes two issues at once. I'm just not sure if we should do it with a round and precision 2 on the return or with a round in the SQL query.