### PR TITLE
[11.0][FIX] l10n_nl_xaf_auditfile_export: enable list of XAF files

### DIFF
--- a/l10n_nl_xaf_auditfile_export/__manifest__.py
+++ b/l10n_nl_xaf_auditfile_export/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "XAF auditfile export",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "author": "Therp BV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Accounting & Finance",

--- a/l10n_nl_xaf_auditfile_export/readme/CONFIGURE.rst
+++ b/l10n_nl_xaf_auditfile_export/readme/CONFIGURE.rst
@@ -1,0 +1,9 @@
+The exporting feature is available to the users who have `Accountant` or `Adviser` rights for accounting.
+
+To configure the default start and end dates of the actual fiscal year, go to `accounting`/`settings` and change the
+last date of the year you want to export. Then in the form of the audit file export, by default the end-date will be set
+accordingly and the start date will be 12 months before the end date.
+Be aware that in case the OCA module `account_fiscal_year` is installed, then the calculus of the fiscal year dates is
+overridden, taking by default the date range defined for the actual fiscal year (check `Settings`/`Date Ranges`).
+
+This module works on huge amount of data, so there is a possibility to encounter out of memory exceptions. In this case. set the config parameter `l10n_nl_xaf_auditfile_export.max_records` to a value much lower than 10000.

--- a/l10n_nl_xaf_auditfile_export/readme/CONTRIBUTORS.rst
+++ b/l10n_nl_xaf_auditfile_export/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Holger Brunn <hbrunn@therp.nl>
+* Andrea Stirpe <a.stirpe@onestein.nl>

--- a/l10n_nl_xaf_auditfile_export/readme/CREDITS.rst
+++ b/l10n_nl_xaf_auditfile_export/readme/CREDITS.rst
@@ -1,0 +1,4 @@
+Icon
+----
+
+https://openclipart.org/detail/180891

--- a/l10n_nl_xaf_auditfile_export/readme/DESCRIPTION.rst
+++ b/l10n_nl_xaf_auditfile_export/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module allows you to export XAF audit files for the Dutch tax authorities (Belastingdienst).
+
+The currently exported version is 3.2

--- a/l10n_nl_xaf_auditfile_export/readme/ROADMAP.rst
+++ b/l10n_nl_xaf_auditfile_export/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+* encrypted and compressed files would be nice

--- a/l10n_nl_xaf_auditfile_export/readme/USAGE.rst
+++ b/l10n_nl_xaf_auditfile_export/readme/USAGE.rst
@@ -1,0 +1,7 @@
+To use this module, you need to:
+
+* be sure that you have `Accountant` or `Adviser` rights for accounting
+* go to `Invoicing`/`Reports`/`Auditfile export`
+* create a new record, adjust values if the defaults are not appropriate
+* click `Generate auditfile`
+* click `Download` on the field `Auditfile`

--- a/l10n_nl_xaf_auditfile_export/views/xaf_auditfile_export.xml
+++ b/l10n_nl_xaf_auditfile_export/views/xaf_auditfile_export.xml
@@ -8,6 +8,7 @@
                 <field name="name" />
                 <field name="date_start" />
                 <field name="date_end" />
+                <field name="date_generated" />
             </tree>
         </field>
     </record>
@@ -49,7 +50,7 @@
         <field name="res_model">xaf.auditfile.export</field>
         <field name="view_mode">tree,form</field>
         <field name="view_type">form</field>
-        <field name="view_id" ref="form_xaf_auditfile_export"/>
+        <field name="view_id" ref="tree_xaf_auditfile_export"/>
         <field name="target">current</field>
     </record>
 


### PR DESCRIPTION
When exporting a XAF audit for companies with a high number of journal entries the computation can take a long time. By default the generated XAF files are attached to the `xaf.auditfile.export` object and they remain like that. The problem is that those objects created in the past are not easily accessible anymore.

This is a simple proposal to enable the list view of the XAF exports, so that the user is able to access the history of the XAF files previously generated.

Fixes https://github.com/OCA/l10n-netherlands/issues/162 for V11.

cc @CasVissers