### PR TITLE
[11.0][IMP] l10n_nl_xaf_auditfile_export: ease extensions

### DIFF
--- a/l10n_nl_xaf_auditfile_export/__manifest__.py
+++ b/l10n_nl_xaf_auditfile_export/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "XAF auditfile export",
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.1.0",
     "author": "Therp BV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Accounting & Finance",

--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -72,10 +72,16 @@ class XafAuditfileExport(models.Model):
                     _('Starting date must be anterior ending date!'))
 
     @api.multi
+    def _get_auditfile_template(self):
+        '''return the qweb template to be rendered'''
+        return "l10n_nl_xaf_auditfile_export.auditfile_template"
+
+    @api.multi
     def button_generate(self):
         self.date_generated = fields.Datetime.now(self)
+        auditfile_template = self._get_auditfile_template()
         xml = self.env['ir.ui.view'].render_template(
-            "l10n_nl_xaf_auditfile_export.auditfile_template",
+            auditfile_template,
             values={
                 'self': self,
             },

--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -24,8 +24,9 @@ class XafAuditfileExport(models.Model):
     _order = 'date_start desc'
 
     @api.depends('name')
-    def _auditfile_name_get(self):
-        self.auditfile_name = '%s.xaf' % self.name
+    def _compute_auditfile_name(self):
+        for item in self:
+            item.auditfile_name = '%s.xaf' % item.name
 
     @api.multi
     def _compute_fiscalyear_name(self):
@@ -39,7 +40,10 @@ class XafAuditfileExport(models.Model):
     fiscalyear_name = fields.Char(compute='_compute_fiscalyear_name')
     auditfile = fields.Binary('Auditfile', readonly=True, copy=False)
     auditfile_name = fields.Char(
-        'Auditfile filename', compute=_auditfile_name_get)
+        'Auditfile filename',
+        compute='_compute_auditfile_name',
+        store=True
+    )
     date_generated = fields.Datetime(
         'Date generated', readonly=True, copy=False)
     company_id = fields.Many2one('res.company', 'Company', required=True)

--- a/l10n_nl_xaf_auditfile_export/tests/__init__.py
+++ b/l10n_nl_xaf_auditfile_export/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_l10n_nl_xaf_auditfile_export

--- a/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
@@ -1,0 +1,51 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestXafAuditfileExport(TransactionCase):
+
+    def test_01_default_values(self):
+        ''' Check that the default values are filled on creation '''
+        record = self.env['xaf.auditfile.export'].create({})
+
+        self.assertTrue(record)
+        self.assertTrue(record.name)
+        self.assertFalse(record.auditfile)
+        self.assertTrue(record.auditfile_name)
+        self.assertTrue(record.company_id)
+        self.assertTrue(record.date_start)
+        self.assertTrue(record.date_end)
+        self.assertFalse(record.date_generated)
+        self.assertTrue(record.fiscalyear_name)
+
+    def test_02_export_success(self):
+        ''' Do a basic auditfile export '''
+        record = self.env['xaf.auditfile.export'].create({})
+        record.button_generate()
+
+        self.assertTrue(record.name)
+        self.assertTrue(record.auditfile)
+        self.assertTrue(record.auditfile_name)
+        self.assertTrue(record.company_id)
+        self.assertTrue(record.date_start)
+        self.assertTrue(record.date_end)
+        self.assertTrue(record.date_generated)
+        self.assertTrue(record.fiscalyear_name)
+
+    def test_03_export_error(self):
+        ''' Failure to export an auditfile '''
+        record = self.env['xaf.auditfile.export'].create({})
+        record.company_id.country_id = False
+        record.button_generate()
+
+        self.assertTrue(record)
+        self.assertTrue(record.name)
+        self.assertFalse(record.auditfile)
+        self.assertTrue(record.auditfile_name)
+        self.assertTrue(record.company_id)
+        self.assertTrue(record.date_start)
+        self.assertTrue(record.date_end)
+        self.assertTrue(record.date_generated)
+        self.assertTrue(record.fiscalyear_name)

--- a/l10n_nl_xaf_auditfile_export/views/xaf_auditfile_export.xml
+++ b/l10n_nl_xaf_auditfile_export/views/xaf_auditfile_export.xml
@@ -31,6 +31,8 @@
                             <field name="date_end" attrs="{'readonly': [('auditfile', '!=', False)]}" />
                         </group>
                     </group>
+                    <group name="input_options">
+                    </group>
                     <group name="output_data" attrs="{'invisible': [('auditfile', '=', False)]}">
                         <field name="date_generated" />
                         <field name="auditfile" filename="auditfile_name" />


### PR DESCRIPTION
With this PR I'm proposing some small changes to ease the extention of `l10n_nl_xaf_auditfile_export` module.

- [x] extract method `_get_auditfile_template()`, to allow to extend this module by modules making use of different qweb templates (forward port of https://github.com/OCA/l10n-netherlands/pull/78);
- [x] make the computed field `auditfile_name` stored, to allow the old generated exports to keep their original name;
- [x] add group in view, to easily allow other modules to add extra options;
- [x] add basic tests to increase the coverage.