### PR TITLE
[11.0][IMP] l10n_nl_xaf_auditfile_export: export auditfiles compatible with Unit4

### DIFF
--- a/l10n_nl_xaf_auditfile_export/__manifest__.py
+++ b/l10n_nl_xaf_auditfile_export/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "XAF auditfile export",
-    "version": "11.0.1.2.1",
+    "version": "11.0.1.3.0",
     "author": "Therp BV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Accounting & Finance",

--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -69,6 +69,18 @@ class XafAuditfileExport(models.Model):
         'Date generated', readonly=True, copy=False)
     company_id = fields.Many2one('res.company', 'Company', required=True)
 
+    unit4 = fields.Boolean(
+        help="The Unit4 system expects a value for "
+             "`<xsd:element name=\"docRef\" ..>` of maximum 35 characters, "
+             "infringing the official standard. In case the value exceeds 35 "
+             "characters, an error is raised by Unit4 while importing the "
+             "audit file. By setting this flag to true, the `docRef` value "
+             "is simply truncated to 35 characters so that the auditfile can "
+             "be successfully imported into Unit4.\n"
+             "If you want to export an auditfile with the official standard "
+             "(missing the Unit4 compatibility) just set this flag to False."
+    )
+
     @api.model
     def default_get(self, fields_list):
         defaults = super(XafAuditfileExport, self).default_get(fields_list)

--- a/l10n_nl_xaf_auditfile_export/readme/DESCRIPTION.rst
+++ b/l10n_nl_xaf_auditfile_export/readme/DESCRIPTION.rst
@@ -1,3 +1,5 @@
 This module allows you to export XAF audit files for the Dutch tax authorities (Belastingdienst).
 
 The currently exported version is 3.2
+
+An option allows to export the XAF audit files in a format that is accepted by Unit4.

--- a/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
@@ -24,6 +24,7 @@ class TestXafAuditfileExport(TransactionCase):
         self.assertTrue(record.date_end)
         self.assertFalse(record.date_generated)
         self.assertTrue(record.fiscalyear_name)
+        self.assertFalse(record.unit4)
 
     def test_02_export_success(self):
         ''' Do a basic auditfile export '''
@@ -38,6 +39,7 @@ class TestXafAuditfileExport(TransactionCase):
         self.assertTrue(record.date_end)
         self.assertTrue(record.date_generated)
         self.assertTrue(record.fiscalyear_name)
+        self.assertFalse(record.unit4)
 
         zf = BytesIO(base64.b64decode(record.auditfile))
         with ZipFile(zf, 'r') as archive:
@@ -63,3 +65,27 @@ class TestXafAuditfileExport(TransactionCase):
         self.assertTrue(record.date_end)
         self.assertTrue(record.date_generated)
         self.assertTrue(record.fiscalyear_name)
+        self.assertFalse(record.unit4)
+
+    def test_04_export_success_unit4(self):
+        ''' Do a basic auditfile export (no Unit4) '''
+        record = self.env['xaf.auditfile.export'].create({})
+        record.unit4 = True
+        record.button_generate()
+
+        self.assertTrue(record.name)
+        self.assertTrue(record.auditfile)
+        self.assertTrue(record.auditfile_name)
+        self.assertTrue(record.company_id)
+        self.assertTrue(record.date_start)
+        self.assertTrue(record.date_end)
+        self.assertTrue(record.date_generated)
+        self.assertTrue(record.fiscalyear_name)
+        self.assertTrue(record.unit4)
+
+        if record.auditfile_name[-4:] == '.zip':
+            zf = BytesIO(base64.b64decode(record.auditfile))
+            with ZipFile(zf, 'r') as archive:
+                filelist = archive.filelist
+                contents = archive.read(filelist[-1]).decode()
+            self.assertTrue(contents.startswith('<?xml '))

--- a/l10n_nl_xaf_auditfile_export/views/templates.xml
+++ b/l10n_nl_xaf_auditfile_export/views/templates.xml
@@ -144,7 +144,7 @@
                     <trLine t-foreach="m.line_ids" t-as="l">
                         <nr><t t-esc="l.id" /></nr>
                         <accID><t t-esc="l.account_id.code" /></accID>
-                        <docRef><t t-esc="l.ref" t-options='{"widget": "auditfile.string999"}' /></docRef>
+                        <docRef><t t-esc="l.ref and l.ref[:35] if self.unit4 == True else l.ref" t-options='{"widget": "auditfile.string999"}' /></docRef>
                         <effDate><t t-esc="l.date" /></effDate>
                         <desc><t t-esc="l.name" /></desc>
                         <amnt><t t-esc="abs(l.balance)" /></amnt>

--- a/l10n_nl_xaf_auditfile_export/views/xaf_auditfile_export.xml
+++ b/l10n_nl_xaf_auditfile_export/views/xaf_auditfile_export.xml
@@ -32,6 +32,7 @@
                         </group>
                     </group>
                     <group name="input_options">
+                        <field name="unit4" attrs="{'readonly': [('auditfile', '!=', False)]}"/>
                     </group>
                     <group name="output_data" attrs="{'invisible': [('auditfile', '=', False)]}">
                         <field name="date_generated" />


### PR DESCRIPTION
This module extends module `l10n_nl_xaf_auditfile_export`: it
allows to export the XAF audit files in a format that is accepted by Unit4.

The Unit4 system expects a value for `<xsd:element name="docRef" ..>` of
maximum 35 characters, infringing the official standard. In case the value
exceeds 35 characters, an error is raised by Unit4 while importing the audit file.
By installing this module, the `docRef` value is simply truncated to 35 characters
so that the auditfile can be successfully imported into Unit4.
