### PR TITLE
[11.0][FIX] l10n_nl_xaf_auditfile_export: add missing auditfile.string35 widget

### DIFF
--- a/l10n_nl_xaf_auditfile_export/__manifest__.py
+++ b/l10n_nl_xaf_auditfile_export/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "XAF auditfile export",
-    "version": "11.0.1.2.0",
+    "version": "11.0.1.2.1",
     "author": "Therp BV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Accounting & Finance",

--- a/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
+++ b/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
@@ -47,6 +47,12 @@ class IrQwebAuditfileStringWidget30(models.AbstractModel):
     _max_length = 30
 
 
+class IrQwebAuditfileStringWidget35(models.AbstractModel):
+    _name = 'ir.qweb.field.auditfile.string35'
+    _inherit = 'ir.qweb.field.auditfile.string999'
+    _max_length = 35
+
+
 class IrQwebAuditfileStringWidget50(models.AbstractModel):
     _name = 'ir.qweb.field.auditfile.string50'
     _inherit = 'ir.qweb.field.auditfile.string999'


### PR DESCRIPTION
Widget auditfile.string35 is missing. Required by https://github.com/OCA/l10n-netherlands/blob/11.0/l10n_nl_xaf_auditfile_export/views/templates.xml#L16