### PR TITLE
[10.0][FIX] l10n_nl_xaf_auditfile_export: add missing auditfile.string35 widget

### DIFF
--- a/l10n_nl_xaf_auditfile_export/__manifest__.py
+++ b/l10n_nl_xaf_auditfile_export/__manifest__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     "name": "XAF auditfile export",
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.0.2",
     "author": "Therp BV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Accounting & Finance",

--- a/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
+++ b/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
@@ -64,6 +64,12 @@ class IrQwebAuditfileStringWidget30(models.AbstractModel):
     _max_length = 30
 
 
+class IrQwebAuditfileStringWidget35(models.AbstractModel):
+    _name = 'ir.qweb.field.auditfile.string35'
+    _inherit = 'ir.qweb.field.auditfile.string999'
+    _max_length = 35
+
+
 class IrQwebAuditfileStringWidget50(models.AbstractModel):
     _name = 'ir.qweb.field.auditfile.string50'
     _inherit = 'ir.qweb.field.auditfile.string999'


### PR DESCRIPTION
Widget auditfile.string35 is missing. Required by https://github.com/OCA/l10n-netherlands/blob/10.0/l10n_nl_xaf_auditfile_export/views/templates.xml#L16