### PR TITLE
fixup! [MIG] Migrates l10n_nl_partner_name from 8.0 to 10.0

### DIFF
--- a/l10n_nl_partner_salutation/data/res_partner_title.xml
+++ b/l10n_nl_partner_salutation/data/res_partner_title.xml
@@ -21,9 +21,5 @@
             <field name="name">Madam</field>
             <field name="salutation">Madam</field>
         </record>
-        <record id="res_partner_title_sir" model="res.partner.title">
-            <field name="name">Sir</field>
-            <field name="salutation">Sir</field>
-        </record>
     </data>
 </odoo>


### PR DESCRIPTION
this title was dropped by the base module, so we don't need to care for it at all