### PR TITLE
[FIX] Rename css classes in l10n_nl_intrastat that mask classes from account_financial_report_qweb

### DIFF
--- a/l10n_nl_intrastat/data/report_layouts.xml
+++ b/l10n_nl_intrastat/data/report_layouts.xml
@@ -21,11 +21,11 @@
         <t t-raw="0" />
         <div class="footer">
             <div class="row">
-                <div class="col-xs-6 custom_footer">
+                <div class="col-xs-6 nl_intra_custom_footer">
                     <span>Printed: </span>
                     <span t-esc="context_timestamp(datetime.datetime.now()).strftime('%Y-%m-%d %H:%M')"/>
                 </div>
-                <div class="col-xs-6 text-right custom_footer">
+                <div class="col-xs-6 text-right nl_intra_custom_footer">
                     <ul class="list-inline">
                         <li><span class="page"/></li>
                         <li>/</li>

--- a/l10n_nl_intrastat/report/l10n_nl_intrastat.xml
+++ b/l10n_nl_intrastat/report/l10n_nl_intrastat.xml
@@ -2,21 +2,21 @@
 <odoo>
 
     <template id="l10n_nl_intrastat.report_nl_intrastat_filters">
-        <div class="act_as_table data_table" style="width: 1140px;">
-            <div class="act_as_row labels">
-                <div class="act_as_cell">Date range</div>
-                <div class="act_as_cell">Company Currency</div>
-                <div class="act_as_cell">Date update</div>
+        <div class="nl_intra_act_as_table nl_intra_data_table" style="width: 1140px;">
+            <div class="nl_intra_act_as_row labels">
+                <div class="nl_intra_act_as_cell">Date range</div>
+                <div class="nl_intra_act_as_cell">Company Currency</div>
+                <div class="nl_intra_act_as_cell">Date update</div>
             </div>
-            <div class="act_as_row">
-                <div class="act_as_cell">
+            <div class="nl_intra_act_as_row">
+                <div class="nl_intra_act_as_cell">
                     <span t-field="o.date_from"/>
                     <span t-field="o.date_to"/>
                 </div>
-                <div class="act_as_cell">
+                <div class="nl_intra_act_as_cell">
                     <span t-field="o.currency_id"/>
                 </div>
-                <div class="act_as_cell">
+                <div class="nl_intra_act_as_cell">
                     <span t-field="o.last_updated"/>
                 </div>
             </div>
@@ -40,36 +40,36 @@
                         </div>
 
                         <!-- Top header -->
-                        <div class="act_as_table data_table" style="width: 1140px;">
+                        <div class="nl_intra_act_as_table nl_intra_data_table" style="width: 1140px;">
                             <!-- Display lines -->
-                            <div class="act_as_row labels">
+                            <div class="nl_intra_act_as_row labels">
                                 <!--## line header-->
-                                <div class="act_as_cell left">Partner</div>
-                                <div class="act_as_cell left">VAT</div>
-                                <div class="act_as_cell left">Country Code</div>
-                                <div class="act_as_cell right">Currency</div>
-                                <div class="act_as_cell right">Amount Product</div>
-                                <div class="act_as_cell right">Amount Service</div>
+                                <div class="nl_intra_act_as_cell left">Partner</div>
+                                <div class="nl_intra_act_as_cell left">VAT</div>
+                                <div class="nl_intra_act_as_cell left">Country Code</div>
+                                <div class="nl_intra_act_as_cell right">Currency</div>
+                                <div class="nl_intra_act_as_cell right">Amount Product</div>
+                                <div class="nl_intra_act_as_cell right">Amount Service</div>
                             </div>
                             <t t-foreach="o.line_ids" t-as="line">
-                                <div class="act_as_row lines">
+                                <div class="nl_intra_act_as_row lines">
                                     <!--## code, description, omzet, btw-->
-                                    <div class="act_as_cell left"><span t-field="line.partner_id"/></div>
-                                    <div class="act_as_cell left"><span t-field="line.vat"/></div>
-                                    <div class="act_as_cell left"><span t-field="line.country_code"/></div>
-                                    <div class="act_as_cell right"><span t-field="line.currency_id"/></div>
-                                    <div class="act_as_cell right"><span t-field="line.amount_product"/></div>
-                                    <div class="act_as_cell right"><span t-field="line.amount_service"/></div>
+                                    <div class="nl_intra_act_as_cell left"><span t-field="line.partner_id"/></div>
+                                    <div class="nl_intra_act_as_cell left"><span t-field="line.vat"/></div>
+                                    <div class="nl_intra_act_as_cell left"><span t-field="line.country_code"/></div>
+                                    <div class="nl_intra_act_as_cell right"><span t-field="line.currency_id"/></div>
+                                    <div class="nl_intra_act_as_cell right"><span t-field="line.amount_product"/></div>
+                                    <div class="nl_intra_act_as_cell right"><span t-field="line.amount_service"/></div>
                                 </div>
                             </t>
-                            <div class="act_as_row labels">
+                            <div class="nl_intra_act_as_row labels">
                                 <!--## total amount-->
-                                <div class="act_as_cell left"> </div>
-                                <div class="act_as_cell left"> </div>
-                                <div class="act_as_cell left"> </div>
-                                <div class="act_as_cell right">Total amount</div>
-                                <div class="act_as_cell right">(product + service)</div>
-                                <div class="act_as_cell right"><span t-field="o.total_amount"/></div>
+                                <div class="nl_intra_act_as_cell left"> </div>
+                                <div class="nl_intra_act_as_cell left"> </div>
+                                <div class="nl_intra_act_as_cell left"> </div>
+                                <div class="nl_intra_act_as_cell right">Total amount</div>
+                                <div class="nl_intra_act_as_cell right">(product + service)</div>
+                                <div class="nl_intra_act_as_cell right"><span t-field="o.total_amount"/></div>
                             </div>
                         </div>
                     </div>

--- a/l10n_nl_intrastat/static/src/css/report.css
+++ b/l10n_nl_intrastat/static/src/css/report.css
@@ -1,22 +1,19 @@
-body, table, td, span, div {
-    font-family: Helvetica, Arial;
-}
-.act_as_table {
+.nl_intra_act_as_table {
     display: table;
 }
-.act_as_row  {
+.nl_intra_act_as_row  {
     display: table-row !important;
     page-break-inside: avoid;
 }
-.act_as_cell {
+.nl_intra_act_as_cell {
     display: table-cell;
     page-break-inside: avoid;
     font-size:18px;
 }
-.act_as_row.labels {
+.nl_intra_act_as_row.labels {
     background-color:#F0F0F0;
 }
-.data_table {
+.nl_intra_data_table {
     width: 100%;
     table-layout: fixed;
     border-left:0px;
@@ -29,21 +26,21 @@ body, table, td, span, div {
     padding-bottom:3px;
     border-collapse:collapse;
 }
-.data_table .act_as_cell{
+.nl_intra_data_table .nl_intra_act_as_cell{
     border-bottom: 1px solid lightGrey;
     text-align: center;
     word-wrap: break-word;
 }
-.data_table .act_as_row.labels {
+.nl_intra_data_table .nl_intra_act_as_row.labels {
     font-weight: bold;
 }
-.act_as_cell.right {
+.nl_intra_act_as_cell.right {
     word-wrap:normal;
     text-align:right;
 }
-.act_as_cell.left {
+.nl_intra_act_as_cell.left {
     text-align:left;
 }
-.custom_footer {
+.nl_intra_custom_footer {
     font-size:18px;
 }


### PR DESCRIPTION
Cf. https://github.com/OCA/l10n-netherlands/pull/155