### PR TITLE
[11.0][IMP] l10n_nl_tax_statement: display detailed move lines

### DIFF
--- a/l10n_nl_tax_statement/__manifest__.py
+++ b/l10n_nl_tax_statement/__manifest__.py
@@ -1,9 +1,9 @@
-# Copyright 2017 Onestein (<http://www.onestein.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2017 Onestein (<https://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
     'name': 'Netherlands BTW Statement',
-    'version': '11.0.2.0.0',
+    'version': '11.0.2.1.0',
     'category': 'Localization',
     'license': 'AGPL-3',
     'author': 'Onestein, Odoo Community Association (OCA)',

--- a/l10n_nl_tax_statement/models/account_tax.py
+++ b/l10n_nl_tax_statement/models/account_tax.py
@@ -64,3 +64,27 @@ class AccountTax(models.Model):
                     ('date', '>=', unreported_date),
                 ]
         return res
+
+    def get_balance_domain(self, state_list, type_list):
+        res = super().get_balance_domain(state_list, type_list)
+        tax_ids = self.env.context.get('l10n_nl_statement_tax_ids')
+        if tax_ids:
+            for item in res:
+                if item[0] == 'tax_line_id':
+                    res.remove(item)
+            res.append(
+                ('tax_line_id', 'in', tax_ids)
+            )
+        return res
+
+    def get_base_balance_domain(self, state_list, type_list):
+        res = super().get_base_balance_domain(state_list, type_list)
+        tax_ids = self.env.context.get('l10n_nl_statement_tax_ids')
+        if tax_ids:
+            for item in res:
+                if item[0] == 'tax_ids':
+                    res.remove(item)
+            res.append(
+                ('tax_ids', 'in', tax_ids)
+            )
+        return res

--- a/l10n_nl_tax_statement/readme/HISTORY.rst
+++ b/l10n_nl_tax_statement/readme/HISTORY.rst
@@ -1,3 +1,9 @@
+11.0.2.1.0
+~~~~~~~~~~
+
+* Added new feature: allow to see the list of movements from selected lines
+  https://github.com/OCA/l10n-netherlands/pull/212
+
 11.0.2.0.0
 ~~~~~~~~~~
 

--- a/l10n_nl_tax_statement/views/l10n_nl_vat_statement_view.xml
+++ b/l10n_nl_tax_statement/views/l10n_nl_vat_statement_view.xml
@@ -58,13 +58,16 @@
                                 </form>
                                 <tree decoration-muted="is_group" editable="bottom" create="false" delete="false">
                                     <field name="is_group" invisible="1"/>
+                                    <field name="is_total" invisible="1"/>
                                     <field name="is_readonly" invisible="1"/>
                                     <field name="code" readonly="1"/>
                                     <field name="name" readonly="1"/>
                                     <field name="format_omzet" invisible="1"/>
                                     <field name="format_btw" invisible="1"/>
                                     <field name="omzet" attrs="{'invisible': [('format_omzet', '=', False)],'readonly': [('is_readonly', '=', True)]}"/>
+                                    <button name="view_base_lines" type="object" string="View base lines" icon="fa-search-plus" attrs="{'invisible': ['|',('format_omzet', '=', False),('is_total', '=', True)]}"/>
                                     <field name="btw" attrs="{'invisible': [('format_btw', '=', False)],'readonly': [('is_readonly', '=', True)]}"/>
+                                    <button name="view_tax_lines" type="object" string="View tax lines" icon="fa-search-plus" attrs="{'invisible': ['|',('format_btw', '=', False),('is_total', '=', True)]}"/>
                                 </tree>
                             </field>
                             <group>

--- a/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.py
+++ b/l10n_nl_tax_statement/wizard/l10n_nl_vat_statement_config_wizard.py
@@ -1,5 +1,5 @@
-# Copyright 2017 Onestein (<http://www.onestein.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2017 Onestein (<https://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
 
@@ -60,9 +60,7 @@ class VatStatementConfigWizard(models.TransientModel):
             defv.setdefault('tag_5b_btw', config.tag_5b_btw.id)
             return defv
 
-        is_l10n_nl_coa = self.env.ref('l10n_nl.l10nnl_chart_template', False)
-        company_coa = self.env.user.company_id.chart_template_id
-        if company_coa != is_l10n_nl_coa:
+        if not self._is_l10n_nl_coa():
             return defv
 
         defv.setdefault('tag_1a_omzet', self.env.ref('l10n_nl.tag_nl_03').id)
@@ -85,6 +83,11 @@ class VatStatementConfigWizard(models.TransientModel):
         defv.setdefault('tag_4b_btw', self.env.ref('l10n_nl.tag_nl_30').id)
         defv.setdefault('tag_5b_btw', self.env.ref('l10n_nl.tag_nl_33').id)
         return defv
+
+    def _is_l10n_nl_coa(self):
+        is_l10n_nl_coa = self.env.ref('l10n_nl.l10nnl_chart_template', False)
+        company_coa = self.env.user.company_id.chart_template_id
+        return company_coa == is_l10n_nl_coa
 
     @api.multi
     def execute(self):


### PR DESCRIPTION
With this PR:

- [x] Added buttons in statement lines to view the related move lines in details
- [x] Added tests
