### PR TITLE
[FIX] suppress extra space if we've just a firstname

### DIFF
--- a/l10n_nl_partner_name/model/res_partner.py
+++ b/l10n_nl_partner_name/model/res_partner.py
@@ -31,7 +31,8 @@ class ResPartner(models.Model):
             self.env.context.get(
                 'name_format',
                 "${firstname or initials or ''}"
-                "${(firstname or initials) and ' ' or ''}"
+                "${(firstname or initials) and (lastname or infix) "
+                "and ' ' or ''}"
                 "${infix or ''}${infix and ' ' or ''}${lastname or ''}"))
         name = name_template.render(**{
             'firstname': firstname,


### PR DESCRIPTION
for partners without a lastname, we generate an extra space which can be hurtful in tests that do comparisons with full partner names