### PR TITLE
[12.0][FIX] l10n_nl_xaf_auditfile_export: message_post() arguments

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -165,7 +165,7 @@ class XafAuditfileExport(models.Model):
 
         except etree.XMLSyntaxError as e:
             logging.getLogger(__name__).error(e)
-            self.message_post(e)
+            self.message_post(body=e)
         finally:
             shutil.rmtree(tmpdir)
             shutil.rmtree(archivedir)


### PR DESCRIPTION
Fixes https://github.com/OCA/l10n-netherlands/issues/228.