### PR TITLE
[12.0][FIX] l10n_nl_bsn: searching on BSN without dots

### DIFF
--- a/l10n_nl_bsn/__manifest__.py
+++ b/l10n_nl_bsn/__manifest__.py
@@ -1,9 +1,9 @@
-# Copyright 2016-2018 Onestein (<https://www.onestein.eu>)
+# Copyright 2016-2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
     'name': 'Burgerservicenummer (BSN) for Partners',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'development_status': 'Production/Stable',
     'category': 'Localization',
     'author': 'Onestein, Odoo Community Association (OCA)',

--- a/l10n_nl_bsn/readme/ROADMAP.rst
+++ b/l10n_nl_bsn/readme/ROADMAP.rst
@@ -1,0 +1,3 @@
+* The 'ilike' search of a substring of a BSN number could not work properly in case the
+  entered BSN number does not contain dots while the corresponding BSN number stored in the
+  database contains dots.

--- a/l10n_nl_bsn/tests/test_l10n_nl_bsn.py
+++ b/l10n_nl_bsn/tests/test_l10n_nl_bsn.py
@@ -11,6 +11,7 @@ class TestBsn(TransactionCase):
 
         self.partner_bsn = self.env['res.partner'].create({
             'name': 'Partner with BSN',
+            'company_id': self.env.user.company_id.id,
         })
 
     def test_01_bsn_not_valid(self):

--- a/l10n_nl_bsn/tests/test_l10n_nl_bsn.py
+++ b/l10n_nl_bsn/tests/test_l10n_nl_bsn.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Onestein (<https://www.onestein.eu>)
+# Copyright 2017-2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import TransactionCase
@@ -7,7 +7,7 @@ from odoo.tests.common import TransactionCase
 class TestBsn(TransactionCase):
 
     def setUp(self):
-        super(TestBsn, self).setUp()
+        super().setUp()
 
         self.partner_bsn = self.env['res.partner'].create({
             'name': 'Partner with BSN',
@@ -36,15 +36,55 @@ class TestBsn(TransactionCase):
 
     def test_03_bsn_another_partner(self):
         new_partner_bsn = self.env['res.partner'].create({
-            'name': 'Partner with BSN',
+            'name': 'Partner with BSN - NEW',
             'bsn_number': '1000.00.009'
         })
+        self.partner_bsn.bsn_number = '100000009'
+        res = self.partner_bsn.onchange_bsn_number()
+        self.assertTrue(res.get('warning'))
         warning = new_partner_bsn._warn_bsn_existing()
         message = warning.get('message')
         self.assertTrue(message)
-        msg_txt = 'Another person (Partner with BSN) ' \
+        msg_txt = 'Another person (Partner with BSN - NEW) ' \
                   'has the same BSN (1000.00.009).'
         self.assertEqual(message, msg_txt)
+        self.assertEqual(message, res['warning']['message'])
         title = warning.get('title')
         self.assertTrue(title)
         self.assertEqual(title, 'Warning!')
+        self.assertEqual(title, res['warning']['title'])
+
+    def test_04_search_bsn_number(self):
+        self.partner_bsn.bsn_number = '100000009'
+        self.partner_bsn.onchange_bsn_number()
+        self.partner_bsn.write({})
+        self.assertEqual(self.partner_bsn.bsn_number, '1000.00.009')
+
+        res = self.env['res.partner'].search([
+            ('bsn_number', '=', '100000009'),
+        ])
+        self.assertEqual(len(res), 1)
+        res = self.env['res.partner'].search([
+            ('bsn_number', '=', '1000.00.009'),
+        ])
+        self.assertEqual(len(res), 1)
+        res = self.env['res.partner'].search([
+            ('bsn_number', 'ilike', '1000.00.00'),
+        ])
+        self.assertEqual(len(res), 1)
+        res = self.env['res.partner'].search([
+            ('bsn_number', 'ilike', '00.00.009'),
+        ])
+        self.assertEqual(len(res), 1)
+        res = self.env['res.partner'].search([
+            ('bsn_number', 'ilike', '00.00.00'),
+        ])
+        self.assertEqual(len(res), 1)
+        res = self.env['res.partner'].search([
+            ('bsn_number', '=', '10000000'),
+        ])
+        self.assertFalse(res)
+        res = self.env['res.partner'].search([
+            ('bsn_number', '=', '1000.00.00'),
+        ])
+        self.assertFalse(res)


### PR DESCRIPTION
Module `l10n_nl_bsn` reformats the BSN by placing dots in the number.
This PR allows the searching on a number even without specifying the dots.

Fixes https://github.com/OCA/l10n-netherlands/issues/231 for V12.
