### PR TITLE
[10.0][FIX] .travis.yml: set postgresql: "9.6"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 cache: pip
 
 addons:
-  postgresql: "9.2" # minimal postgresql version for the daterange method
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility


### PR DESCRIPTION
Branch 10.0 seems broken at the moment. 