### PR TITLE
[12.0][FIX] l10n_nl_xaf_auditfile_export: avoid character / in filename

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -135,6 +135,7 @@ class XafAuditfileExport(models.Model):
             'xmlns="http://www.auditfiles.nl/XAF/3.2">', 1)
 
         filename = self.name + '.xaf'
+        filename = filename.replace(os.sep, ' ')
         tmpdir = mkdtemp()
         auditfile = os.path.join(tmpdir, filename)
         archivedir = mkdtemp()

--- a/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
@@ -3,6 +3,7 @@
 
 import base64
 from io import BytesIO
+import os
 from zipfile import ZipFile
 
 from odoo.tests.common import TransactionCase
@@ -89,3 +90,10 @@ class TestXafAuditfileExport(TransactionCase):
                 filelist = archive.filelist
                 contents = archive.read(filelist[-1]).decode()
             self.assertTrue(contents.startswith('<?xml '))
+
+    def test_05_export_success(self):
+        ''' Export auditfile with / character in filename '''
+        record = self.env['xaf.auditfile.export'].create({})
+        record.name += '%s01' % os.sep
+        record.button_generate()
+        self.assertTrue(record)


### PR DESCRIPTION
When the auditfile name contains a `/` character, for example `My Company XYZ/11`, the export fails with the following error:

```
  File "/opt/odoo/custom_addons/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py", line 139, in button_generate

    with open(auditfile, 'w+') as tmphandle:

FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmps5yzgrqz/My Company XYZ/11.xaf'

```

This PR replaces the `/` character with a blank.