### PR TITLE
[11.0][IMP] l10n_nl_postcodeapi: mock tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ env:
     - LINT_CHECK="1"
     - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="l10n_nl_postcodeapi"
     - TESTS="1" ODOO_REPO="odoo/odoo" MAKEPOT="1" EXCLUDE="l10n_nl_postcodeapi"
+    - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="l10n_nl_postcodeapi"
+    - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="l10n_nl_postcodeapi"
 
 
 install:


### PR DESCRIPTION
This PR converts tests of module `l10n_nl_postcodeapi` in order to make use of offline mock tests instead of real connections to PostcodeAPI service.