### PR TITLE
[13.0] l10n_nl_xaf_auditfile_export only posted moves

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -337,6 +337,7 @@ class XafAuditfileExport(models.Model):
                     ("date", ">=", self.date_start),
                     ("date", "<=", self.date_end),
                     ("journal_id", "=", journal.id),
+                    ("state", "=", "posted"),
                 ]
             )
             .ids


### PR DESCRIPTION
The XAF file should only used posted moves. Cancelled and draft moves should be skipped.

@astirpe 