### PR TITLE
[13.0] [FIX] l10n_nl_xaf_auditfile_export. flake8.

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -19,12 +19,12 @@ from lxml import etree
 from odoo import _, api, exceptions, fields, models, modules, release
 
 
-def chunks(l, n=None):
-    """Yield successive n-sized chunks from l."""
+def chunks(ids, n=None):
+    """Yield successive n-sized chunks from ids list."""
     if n is None:
         n = models.PREFETCH_MAX
-    for i in range(0, len(l), n):
-        yield l[i : i + n]
+    for i in range(0, len(ids), n):
+        yield ids[i : i + n]
 
 
 def memory_info():


### PR DESCRIPTION
Prevent E741 ambiguous variable name 'l'.