### PR TITLE
[UPD] new VAT tariff

### DIFF
--- a/l10n_nl_tax_declaration_reporting/i18n/l10n_nl_tax_declaration_reporting.pot
+++ b/l10n_nl_tax_declaration_reporting/i18n/l10n_nl_tax_declaration_reporting.pot
@@ -20,7 +20,7 @@ msgstr ""
 
 #. module: l10n_nl_tax_declaration_reporting
 #: view:website:l10n_nl_tax_declaration_reporting.tax_report_template
-msgid "1b Leveringen/diensten belast met 6%"
+msgid "1b Leveringen/diensten belast met 9%"
 msgstr ""
 
 #. module: l10n_nl_tax_declaration_reporting

--- a/l10n_nl_tax_declaration_reporting/views/account_tax_report.xml
+++ b/l10n_nl_tax_declaration_reporting/views/account_tax_report.xml
@@ -74,7 +74,7 @@
                                             <td style="text-align:right"> € <t t-esc="_1AB"/></td>
                                           </tr>
                                           <tr>
-                                            <td> 1b Leveringen/diensten belast met 6%</td>
+                                            <td> 1b Leveringen/diensten belast met 9%</td>
                                             <td style="text-align:right"> € <t t-esc="_1BO"/></td>
                                             <td style="text-align:right"> € <t t-esc="_1BB"/></td>
                                           </tr>


### PR DESCRIPTION
This could have been done in a much more future-proof way, eg. to get the percentage from the actual `account.tax.code` record being referenced, but as this is a legacy 8.0 report I'm not too bothered.