### PR TITLE
[13.0] [FIX] l10n_nl_oin: Dont use company_type for business logic

### DIFF
--- a/l10n_nl_oin/models/res_partner.py
+++ b/l10n_nl_oin/models/res_partner.py
@@ -12,10 +12,10 @@ class ResPartner(models.Model):
     )
     nl_oin_display = fields.Boolean(compute="_compute_nl_oin_display")
 
-    @api.depends("country_id", "company_type")
+    @api.depends("country_id", "is_company")
     def _compute_nl_oin_display(self):
         for partner in self:
-            if partner.company_type != "company":
+            if not partner.is_company:
                 partner.nl_oin_display = False
             elif partner.country_id != self.env.ref("base.nl"):
                 partner.nl_oin_display = False

--- a/l10n_nl_oin/readme/DESCRIPTION.rst
+++ b/l10n_nl_oin/readme/DESCRIPTION.rst
@@ -1,7 +1,7 @@
 This module adds the Dutch `Organisatie-identificatienummer (OIN)` field
 on partner forms.
 
-The field is visible when the field ``company_type`` is set to ``Company``.
+The field is visible when the partner is a company.
 
 A double check on the OIN is done when inserting/modifying its value:
 

--- a/l10n_nl_oin/tests/test_l10n_nl_oin.py
+++ b/l10n_nl_oin/tests/test_l10n_nl_oin.py
@@ -13,7 +13,7 @@ class TestOin(TransactionCase):
                 "name": "Partner with OIN",
                 "company_id": self.env.company.id,
                 "country_id": self.env.ref("base.nl").id,
-                "company_type": "company",
+                "is_company": True,
             }
         )
 
@@ -70,5 +70,5 @@ class TestOin(TransactionCase):
         self.assertFalse(self.partner_oin.nl_oin_display)
 
         self.partner_oin.country_id = self.env.ref("base.nl")
-        self.partner_oin.company_type = "person"
+        self.partner_oin.is_company = False
         self.assertFalse(self.partner_oin.nl_oin_display)

--- a/l10n_nl_oin/tests/test_l10n_nl_oin.py
+++ b/l10n_nl_oin/tests/test_l10n_nl_oin.py
@@ -8,13 +8,17 @@ class TestOin(TransactionCase):
     def setUp(self):
         super().setUp()
 
-        self.partner_oin = self.env["res.partner"].create(
-            {
-                "name": "Partner with OIN",
-                "company_id": self.env.company.id,
-                "country_id": self.env.ref("base.nl").id,
-                "is_company": True,
-            }
+        self.partner_oin = (
+            self.env["res.partner"]
+            .create(
+                {
+                    "name": "Partner with OIN",
+                    "company_id": self.env.company.id,
+                    "country_id": self.env.ref("base.nl").id,
+                    "is_company": True,
+                }
+            )
+            .with_context(lang="en_US")
         )
 
     def test_01_oin_not_valid(self):
@@ -39,12 +43,16 @@ class TestOin(TransactionCase):
         self.assertFalse(warning)
 
     def test_03_oin_another_partner(self):
-        new_partner_oin = self.env["res.partner"].create(
-            {
-                "name": "Partner with OIN - NEW",
-                "nl_oin": "12345678901234567890",
-                "company_id": self.env.company.id,
-            }
+        new_partner_oin = (
+            self.env["res.partner"]
+            .create(
+                {
+                    "name": "Partner with OIN - NEW",
+                    "nl_oin": "12345678901234567890",
+                    "company_id": self.env.company.id,
+                }
+            )
+            .with_context(lang="en_US")
         )
         self.partner_oin.nl_oin = "12345678901234567890"
         res = self.partner_oin.onchange_nl_oin()


### PR DESCRIPTION
Follows [Odoo guidance](https://github.com/OCA/OCB/blob/13.0/odoo/addons/base/models/res_partner.py#L206) on this topic.