### PR TITLE
[12.0][IMP] Refactor to base postcodeapi on postcode check.

### DIFF
--- a/l10n_nl_postcode/models/res_partner.py
+++ b/l10n_nl_postcode/models/res_partner.py
@@ -1,4 +1,5 @@
 # Copyright 2016-2018 Onestein (<http://www.onestein.eu>)
+# Copyright 2020 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import logging
@@ -13,39 +14,44 @@ except ImportError:
 
 
 class ResPartner(models.Model):
+    """Add functions to check dutch postcode."""
     _inherit = 'res.partner'
 
     @api.multi
-    def _l10n_nl_postcode_get_warning(self):
+    def _l10n_nl_postcode_get_warning(self, message):
+        """Utility to set warning message for onchange methods."""
         self.ensure_one()
-        msg = _('The Postcode you entered (%s) is not valid.')
         warning = {
             'title': _('Warning!'),
-            'message': msg % self.zip,
+            'message': message % self.zip,
         }
         return warning
 
     @api.multi
-    def _l10n_nl_postcode_check_country(self):
+    def _l10n_nl_do_check_postcode(self):
+        """Only check postcode for Dutch addresses and when not disabled in context."""
         self.ensure_one()
-        country = self.country_id
-        if not country or country != self.env.ref('base.nl'):
+        # if 'skip_postcode_check' passed in context: will disable the check
+        if self.env.context.get('skip_postcode_check'):
+            return False
+        # If not explicitly in the Netherlands do not check:
+        if not self.country_id or self.country_id != self.env.ref('base.nl'):
             return False
         return True
 
-    @api.multi
     @api.onchange('zip', 'country_id')
     def onchange_zip_l10n_nl_postcode(self):
-        # if 'skip_postcode_check' passed in context: will disable the check
-        if self.env.context.get('skip_postcode_check'):
-            return
-
-        if self.zip and self._l10n_nl_postcode_check_country():
-            # check that the postcode is valid
-            if postcode.is_valid(self.zip):
-                # properly format the entered postcode
-                self.zip = postcode.validate(self.zip)
-            else:
-                # display a warning
-                warning_msg = self._l10n_nl_postcode_get_warning()
-                return {'warning': warning_msg, }
+        """Check postcode if country is or becomes Netherlands and field has value."""
+        result = {}
+        if not self._l10n_nl_do_check_postcode():
+            return result
+        # check that the postcode is valid
+        if postcode.is_valid(self.zip):
+            # properly format the entered postcode
+            self.zip = postcode.validate(self.zip)
+        else:
+            # display a warning
+            result['warning'] = self._l10n_nl_postcode_get_warning(
+                _('The Postcode you entered (%s) is not valid.')
+            )
+        return result

--- a/l10n_nl_postcodeapi/__manifest__.py
+++ b/l10n_nl_postcodeapi/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Therp BV <https://therp.nl>
+# Copyright 2013-2020 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
@@ -9,10 +9,8 @@
     'category': 'Localization',
     'website': 'https://github.com/OCA/l10n-netherlands',
     'license': 'AGPL-3',
-    'depends': ['base_address_extended'],
-    'data': [
-        'data/ir_config_parameter.xml',
-        ],
+    'depends': ['base_address_extended', 'l10n_nl_postcode'],
+    'data': ['data/ir_config_parameter.xml'],
     'external_dependencies': {
         'python': ['pyPostcode'],
     },

--- a/l10n_nl_postcodeapi/tests/test_l10n_nl_postcodeapi.py
+++ b/l10n_nl_postcodeapi/tests/test_l10n_nl_postcodeapi.py
@@ -106,7 +106,7 @@ class TestNlPostcodeapi(TransactionCase):
 
         partner = self.create_partner()
         with self.patch_api_get_address():
-            partner.on_change_zip_street_number()
+            partner.onchange_zip_l10n_nl_postcode()
 
         partner._convert_to_write(partner._cache)
         self.assertEqual(partner.street_name, 'Claudius Prinsenlaan')
@@ -120,7 +120,7 @@ class TestNlPostcodeapi(TransactionCase):
 
         partner = self.create_partner()
         with self.patch_api_get_address():
-            partner.on_change_zip_street_number()
+            partner.onchange_zip_l10n_nl_postcode()
 
         partner._convert_to_write(partner._cache)
         self.assertEqual(partner.street_name, 'Claudius Prinsenlaan')
@@ -133,7 +133,7 @@ class TestNlPostcodeapi(TransactionCase):
 
         partner = self.create_partner(country="IT")
         with self.patch_api_get_address() as getaddr:
-            partner.on_change_zip_street_number()
+            partner.onchange_zip_l10n_nl_postcode()
         getaddr.assert_not_called()
 
         partner._convert_to_write(partner._cache)
@@ -145,7 +145,7 @@ class TestNlPostcodeapi(TransactionCase):
     def test_06_res_partner_no_key(self):
         partner = self.create_partner()
         with self.patch_api_get_address() as getaddr:
-            partner.on_change_zip_street_number()
+            partner.onchange_zip_l10n_nl_postcode()
         getaddr.assert_not_called()
 
         partner._convert_to_write(partner._cache)
@@ -159,7 +159,7 @@ class TestNlPostcodeapi(TransactionCase):
         partner = self.create_partner()
         with self.patch_api_get_address() as getaddr:
             getaddr.return_value = False
-            partner.on_change_zip_street_number()
+            partner.onchange_zip_l10n_nl_postcode()
         getaddr.assert_called_with("3811DJ", "10")
 
         partner._convert_to_write(partner._cache)
@@ -173,7 +173,7 @@ class TestNlPostcodeapi(TransactionCase):
 
         partner = self.create_partner()
         with self.patch_api_get_address(province=""):
-            partner.on_change_zip_street_number()
+            partner.onchange_zip_l10n_nl_postcode()
 
         partner._convert_to_write(partner._cache)
         self.assertEqual(partner.street_name, 'Claudius Prinsenlaan')


### PR DESCRIPTION
- Only retrieve postcode if this has a valid format;
- Refactor to make methods re-usable and re-use them;
- Provide a warning when postcode is not valid instead of ignoring problem.