### PR TITLE
[13.0][FIX] l10n_nl_xaf_auditfile_export: error bankAccNr length limit exceeded

### DIFF
--- a/l10n_nl_xaf_auditfile_export/views/templates.xml
+++ b/l10n_nl_xaf_auditfile_export/views/templates.xml
@@ -60,7 +60,7 @@
                     <country t-if="p.country_id"><t t-esc="p.country_id.code" /></country>
                 </streetAddress>
                 <bankAccount t-foreach="p.bank_ids" t-as="bank">
-                    <bankAccNr><t t-esc="bank.acc_number" /></bankAccNr>
+                    <bankAccNr><t t-esc="bank.sanitized_acc_number" /></bankAccNr>
                     <bankIdCd><t t-esc="bank.bank_bic or bank.bank_id.bic" /></bankIdCd>
                 </bankAccount>
                 <changeInfo t-if="p.write_uid">


### PR DESCRIPTION
This fixes the following error:

`Element '{http://www.auditfiles.nl/XAF/3.2}bankAccNr': [facet 'maxLength'] The value has a length of '38'; this exceeds the allowed maximum length of '35'.`

This error could occur in case `acc_number` string contains spaces.