### PR TITLE
[12.0][IMP] l10n_nl_tax_statement: by default, don't include moves from before the earliest statement

### DIFF
--- a/l10n_nl_tax_statement/models/account_move_line.py
+++ b/l10n_nl_tax_statement/models/account_move_line.py
@@ -8,11 +8,13 @@ class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
     l10n_nl_vat_statement_id = fields.Many2one(
+        index=True,
         related='move_id.l10n_nl_vat_statement_id',
         store=True,
         string='Related Move Statement'
     )
     l10n_nl_vat_statement_include = fields.Boolean(
+        index=True,
         related='move_id.l10n_nl_vat_statement_include',
         store=True,
     )

--- a/l10n_nl_tax_statement/tests/test_l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/tests/test_l10n_nl_vat_statement.py
@@ -109,6 +109,16 @@ class TestVatStatement(TransactionCase):
         })
 
     def test_01_onchange(self):
+        """ Unreported move from date is bound by the earliest start date,
+        and set to three months earlier otherwise.
+        """
+        form_0 = Form(self.env['l10n.nl.vat.statement'])
+        form_0.from_date = fields.Date.from_string('1975-01-01')
+        self.assertEqual(
+            form_0.unreported_move_from_date, form_0.from_date)
+        form_0.to_date = fields.Date.from_string('1975-12-31')
+        statement_0 = form_0.save()
+
         daterange_type = self.env['date.range.type'].create({
             'name': 'Type 1'
         })
@@ -141,6 +151,10 @@ class TestVatStatement(TransactionCase):
         self.assertEqual(statement.unreported_move_from_date, new_date)
 
         self.assertEqual(statement.btw_total, 0.)
+
+        form.from_date = fields.Date.from_string('1975-02-01')
+        self.assertEqual(
+            form.unreported_move_from_date, statement_0.from_date)
 
     def test_02_post_final(self):
         # in draft


### PR DESCRIPTION
Improve performance drastically for older databases by not selecting all historic moves when creating the first tax statement, by setting a minimum default cutoff date for unreported moves to the date of the earliest tax statement (or the statement's "from date" if it is the first).