### PR TITLE
[12.0][FIX] l10n_nl_tax_statement: remove duplicate method

### DIFF
--- a/l10n_nl_tax_statement/models/account_tax.py
+++ b/l10n_nl_tax_statement/models/account_tax.py
@@ -8,28 +8,6 @@ from odoo.osv import expression
 class AccountTax(models.Model):
     _inherit = 'account.tax'
 
-    def get_move_line_partial_domain(self, from_date, to_date, company_id):
-        res = super().get_move_line_partial_domain(
-            from_date,
-            to_date,
-            company_id
-        )
-
-        if not self.env.context.get('skip_invoice_basis_domain'):
-            return res
-
-        if not self.env.context.get('unreported_move'):
-            return res
-
-        # Both 'skip_invoice_basis_domain' and 'unreported_move' must be set
-        # in context, in order to get the domain for the unreported invoices
-        return expression.AND([
-            [('company_id', '=', company_id)],
-            [('l10n_nl_vat_statement_id', '=', False)],
-            [('l10n_nl_vat_statement_include', '=', True)],
-            self._get_move_line_tax_date_range_domain(from_date),
-        ])
-
     @api.model
     def _get_move_line_tax_date_range_domain(self, from_date):
         unreported_date = self.env.context.get('unreported_move_from_date')


### PR DESCRIPTION
Method occurs twice in the same class. Here is the other occurrence of the method: https://github.com/VanMoof/l10n-netherlands/blob/12.0/l10n_nl_tax_statement/models/account_tax.py#L93-L101. I'm removing the method that is currently not used, as it comes earlier in the class definition. Please advise if that is the right method to remove.
