### PR TITLE
[12.0][FIX] l10n_nl_tax_statement: error when fiscal year is present

### DIFF
--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
@@ -1,7 +1,7 @@
 # Copyright 2017-2019 Onestein (<https://www.onestein.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from datetime import datetime
+from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
@@ -216,8 +216,18 @@ class VatStatement(models.Model):
         defaults = super().default_get(fields_list)
         company = self.env.user.company_id
         fy_dates = company.compute_fiscalyear_dates(datetime.now())
-        defaults.setdefault('from_date', datetime.date(fy_dates['date_from']))
-        defaults.setdefault('to_date', datetime.date(fy_dates['date_to']))
+        defaults.setdefault(
+            'from_date',
+            datetime.date(fy_dates['date_from'])
+            if type(fy_dates['date_from']) != date
+            else fy_dates['date_from']
+        )
+        defaults.setdefault(
+            'to_date',
+            datetime.date(fy_dates['date_to'])
+            if type(fy_dates['date_to']) != date
+            else fy_dates['date_to']
+        )
         defaults.setdefault('name', company.name)
         defaults.setdefault(
             'unreported_move_from_date',

--- a/l10n_nl_tax_statement/tests/test_l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/tests/test_l10n_nl_vat_statement.py
@@ -622,3 +622,26 @@ class TestVatStatement(TransactionCase):
 
         company_ids_full_list = statement_parent._get_company_ids_full_list()
         self.assertEqual(len(company_ids_full_list), 3)
+
+    def test_21_defaults_with_fiscalyear(self):
+        """
+        res.company's compute_fiscalyear_dates() returns date values instead
+        of datetime when a fiscal year is present.
+        """
+        today = fields.Date.context_today(self.env.user)
+        date_from = today.replace(month=1, day=1)
+        date_to = today.replace(month=12, day=31)
+        if not self.env["account.fiscal.year"].search(
+                [("date_from", "<=", today),
+                 ("date_to", ">=", today),
+                 ("company_id", "=", self.env.user.company_id.id)]):
+            self.env["account.fiscal.year"].create({
+                "name": "This year",
+                "date_from": date_from,
+                "date_to": date_to,
+            })
+        form = Form(self.env['l10n.nl.vat.statement'])
+        self.assertEqual(
+            form.from_date[:10], fields.Date.to_string(date_from))
+        self.assertEqual(
+            form.to_date[:10], fields.Date.to_string(date_to))


### PR DESCRIPTION
When fiscal year entries are present, res.company's compute_fiscalyear_dates
method returns date type values instead of datetime values. Date type values
raise an error when being cast to a date type again.

Regression of #310, which coerces the values to the date type for further
processing.