### PR TITLE
[14.0][FIX] l10n_nl_xaf_auditfile: Added Netherlands Antilles to Country and Currency Lists

### DIFF
--- a/l10n_nl_xaf_auditfile_export/data/XmlAuditfileFinancieel3.2.xsd
+++ b/l10n_nl_xaf_auditfile_export/data/XmlAuditfileFinancieel3.2.xsd
@@ -651,6 +651,7 @@
 			<xsd:enumeration value="AI" />
 			<xsd:enumeration value="AL" />
 			<xsd:enumeration value="AM" />
+			<xsd:enumeration value="AN" />
 			<xsd:enumeration value="AO" />
 			<xsd:enumeration value="AQ" />
 			<xsd:enumeration value="AR" />


### PR DESCRIPTION
The XSD file in the module currently differs only from the latest official XSD file in that the Netherlands Antilles was missing from the country and currency list resulting in a failure to generate the XAF auditfile if one of the customers or suppliers is located in this country. This fix corrects that.