### PR TITLE
[14.0][FIX] Only include move lines that have been posted in the SQL queries

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -257,6 +257,7 @@ class XafAuditfileExport(models.Model):
             "     account_account_type t "
             "where a.user_type_id = t.id "
             "and l.account_id = a.id "
+            "and l.parent_state = 'posted' "
             "and l.date < %s "
             "and l.company_id=%s "
             "and t.include_initial_balance = true ",
@@ -278,6 +279,7 @@ class XafAuditfileExport(models.Model):
             "where a.user_type_id = t.id "
             "and a.id = l.account_id and l.date < %s "
             "and l.company_id=%s "
+            "and l.parent_state = 'posted' "
             "and t.include_initial_balance = true "
             "group by a.id, a.code",
             (self.date_start, self.company_id.id),
@@ -295,6 +297,7 @@ class XafAuditfileExport(models.Model):
             "select count(*) from account_move_line "
             "where date >= %s "
             "and date <= %s "
+            "and parent_state = 'posted' "
             "and company_id=%s",
             (self.date_start, self.date_end, self.company_id.id),
         )
@@ -306,6 +309,7 @@ class XafAuditfileExport(models.Model):
             "select sum(debit) from account_move_line "
             "where date >= %s "
             "and date <= %s "
+            "and parent_state = 'posted' "
             "and company_id=%s",
             (self.date_start, self.date_end, self.company_id.id),
         )
@@ -317,6 +321,7 @@ class XafAuditfileExport(models.Model):
             "select sum(credit) from account_move_line "
             "where date >= %s "
             "and date <= %s "
+            "and parent_state = 'posted' "
             "and company_id=%s",
             (self.date_start, self.date_end, self.company_id.id),
         )


### PR DESCRIPTION
The SQL queries to get opening balance totals, opening balance entries, move line count and move line total debit and credit did not filter for only posted lines. This fix corrects that.  