### PR TITLE
[12.0][IMP] l10n_nl_tax_statement_icp: optionally split amounts by product type

### DIFF
--- a/l10n_nl_tax_statement_icp/README.rst
+++ b/l10n_nl_tax_statement_icp/README.rst
@@ -47,6 +47,18 @@ To configure this module, you need to:
 
 #. Follow the configuration steps as described in *l10n_nl_tax_statement* and set the tag *3b omzet* needed for this report.
 
+On the ICP Statement, the amounts will be split up into an amount for products
+and an amount for services. The Dutch chart of accounts in Odoo provides
+a separate set of taxes for services which ensure that the amounts are split
+up properly here as well. If you are migrating from a legacy situation or you
+do not want to apply separate taxes to service products, you can set a *System
+Parameter* with key
+*l10n_nl_tax_statement_icp.icp_amount_by_tag_or_product* to value *product*.
+
+With this configuration in place, the amounts will be split up according to
+the product type, using service by default when no product is mentioned on
+the invoice line.
+
 Usage
 =====
 

--- a/l10n_nl_tax_statement_icp/__manifest__.py
+++ b/l10n_nl_tax_statement_icp/__manifest__.py
@@ -12,6 +12,7 @@
         'l10n_nl_tax_statement',
     ],
     'data': [
+        'data/ir_config_parameter.xml',
         'security/ir.model.access.csv',
         'views/l10n_nl_vat_statement_view.xml',
         'views/report_tax_statement.xml',

--- a/l10n_nl_tax_statement_icp/data/ir_config_parameter.xml
+++ b/l10n_nl_tax_statement_icp/data/ir_config_parameter.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="1">
+    <record model="ir.config_parameter" id="parameter_icp_amount">
+        <field name="key">l10n_nl_tax_statement_icp.icp_amount_by_tag_or_product</field>
+        <field name="value">tag</field>
+    </record>
+</odoo>

--- a/l10n_nl_tax_statement_icp/readme/CONFIGURE.rst
+++ b/l10n_nl_tax_statement_icp/readme/CONFIGURE.rst
@@ -1,3 +1,15 @@
 To configure this module, you need to:
 
 #. Follow the configuration steps as described in *l10n_nl_tax_statement* and set the tag *3b omzet* needed for this report.
+
+On the ICP Statement, the amounts will be split up into an amount for products
+and an amount for services. The Dutch chart of accounts in Odoo provides
+a separate set of taxes for services which ensure that the amounts are split
+up properly here as well. If you are migrating from a legacy situation or you
+do not want to apply separate taxes to service products, you can set a *System
+Parameter* with key
+*l10n_nl_tax_statement_icp.icp_amount_by_tag_or_product* to value *product*.
+
+With this configuration in place, the amounts will be split up according to
+the product type, using service by default when no product is mentioned on
+the invoice line.

--- a/l10n_nl_tax_statement_icp/static/description/index.html
+++ b/l10n_nl_tax_statement_icp/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Netherlands ICP Statement</title>
 <style type="text/css">
 
@@ -397,6 +397,16 @@ The period is also the same as the one selected in the BTW aangifte report.</p>
 <ol class="arabic simple">
 <li>Follow the configuration steps as described in <em>l10n_nl_tax_statement</em> and set the tag <em>3b omzet</em> needed for this report.</li>
 </ol>
+<p>On the ICP Statement, the amounts will be split up into an amount for products
+and an amount for services. The Dutch chart of accounts in Odoo provides
+a separate set of taxes for services which ensure that the amounts are split
+up properly here as well. If you are migrating from a legacy situation or you
+do not want to apply separate taxes to service products, you can set a <em>System
+Parameter</em> with key
+<em>l10n_nl_tax_statement_icp.icp_amount_by_tag_or_product</em> to value <em>product</em>.</p>
+<p>With this configuration in place, the amounts will be split up according to
+the product type, using service by default when no product is mentioned on
+the invoice line.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id2">Usage</a></h1>


### PR DESCRIPTION
When migrating from a legacy version of Odoo that did not have the dedicated service taxes from later version of the Dutch chart of account, reassigning the service taxes on existing entries or even introducing their usage may not be the most straightforward thing to do. But without it, the amounts on the ICP lines will not be split up correctly between products and services. This PR introduces a parameter that restores the behaviour from the old NL ICP module to split up the amounts based on the product type.
