### PR TITLE
[12.0] l10n_nl_xaf_auditfile_export: include lines from inactive journals

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -287,9 +287,10 @@ class XafAuditfileExport(models.Model):
     @api.multi
     def get_journals(self):
         '''return journals'''
-        return self.env['account.journal'].search([
-            ('company_id', '=', self.company_id.id),
-        ])
+        return self.env['account.journal'].with_context(
+            active_test=False).search([
+                ('company_id', '=', self.company_id.id),
+            ])
 
     @api.multi
     def get_moves(self, journal):


### PR DESCRIPTION
This change makes the contents of the auditfile complete as it includes the lines of inactive journals. 
original contribution by @StefanRijnhart 