### PR TITLE
[FIX][IMP][10.0] l10n_xaf_auditfile_export: Invalid characters removal

### DIFF
--- a/l10n_nl_tax_invoice_basis/tests/test_tax_invoice_basis.py
+++ b/l10n_nl_tax_invoice_basis/tests/test_tax_invoice_basis.py
@@ -28,7 +28,7 @@ class TestTaxInvoiceBasis(TransactionCase):
             'account_id': receivable_account_id,
             'date_invoice': '2017-08-18',
             'date': '2017-07-01',
-            'type': 'in_invoice',
+            'type': 'out_refund',
         })
         invoice_line_account_id = self.env['account.account'].search(
             [('user_type_id', '=', self.env.ref(

--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -28,6 +28,7 @@ import psutil
 import shutil
 from tempfile import mkdtemp
 from io import BytesIO
+import sys
 import zipfile
 import time
 import traceback
@@ -50,6 +51,25 @@ def memory_info():
     process = psutil.Process(os.getpid())
     pmem = (getattr(process, 'memory_info', None) or process.get_memory_info)()
     return pmem.vms
+
+
+# http://stackoverflow.com/questions/1707890/fast-way-to-filter-illegal-xml-unicode-chars-in-python
+ILLEGAL_RANGES = [
+    (0x00, 0x08), (0x0B, 0x1F), (0x7F, 0x84), (0x86, 0x9F),
+    (0xD800, 0xDFFF), (0xFDD0, 0xFDDF), (0xFFFE, 0xFFFF),
+    (0x1FFFE, 0x1FFFF), (0x2FFFE, 0x2FFFF), (0x3FFFE, 0x3FFFF),
+    (0x4FFFE, 0x4FFFF), (0x5FFFE, 0x5FFFF), (0x6FFFE, 0x6FFFF),
+    (0x7FFFE, 0x7FFFF), (0x8FFFE, 0x8FFFF), (0x9FFFE, 0x9FFFF),
+    (0xAFFFE, 0xAFFFF), (0xBFFFE, 0xBFFFF), (0xCFFFE, 0xCFFFF),
+    (0xDFFFE, 0xDFFFF), (0xEFFFE, 0xEFFFF), (0xFFFFE, 0xFFFFF),
+    (0x10FFFE, 0x10FFFF)
+]
+UNICODE_SANITIZE_TRANSLATION = {}
+for low, high in ILLEGAL_RANGES:
+    if low > sys.maxunicode:  # pragma: no cover
+        continue
+    for c in range(low, high+1):
+        UNICODE_SANITIZE_TRANSLATION[c] = ord(u' ')
 
 
 class XafAuditfileExport(models.Model):
@@ -84,6 +104,7 @@ class XafAuditfileExport(models.Model):
         compute='_compute_auditfile_name',
         store=True
     )
+    auditfile_success = fields.Boolean()
     date_generated = fields.Datetime(
         'Date generated', readonly=True, copy=False)
     company_id = fields.Many2one('res.company', 'Company', required=True)
@@ -137,7 +158,11 @@ class XafAuditfileExport(models.Model):
             u'<?xml version="1.0" encoding="UTF-8"?>'
             '<auditfile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
             'xmlns="http://www.auditfiles.nl/XAF/3.2">', 1)
-
+        # removes invalid characters from xml
+        if not self.env.context.get('dont_sanitize_xml'):
+            xml = xml.translate(
+                UNICODE_SANITIZE_TRANSLATION
+            )
         filename = self.name + '.xaf'
         tmpdir = mkdtemp()
         auditfile = os.path.join(tmpdir, filename)
@@ -174,6 +199,7 @@ class XafAuditfileExport(models.Model):
             logging.getLogger(__name__).error(e)
             logging.getLogger(__name__).info(traceback.format_exc())
             self.message_post(e)
+            self.auditfile_success = False
 
         finally:
             shutil.rmtree(tmpdir)

--- a/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
@@ -38,6 +38,7 @@ class TestXafAuditfileExport(TransactionCase):
         self.assertTrue(record.date_end)
         self.assertTrue(record.date_generated)
         self.assertTrue(record.fiscalyear_name)
+        self.assertTrue(record.auditfile_success)
 
         zf = BytesIO(base64.b64decode(record.auditfile))
         with ZipFile(zf, 'r') as archive:
@@ -56,7 +57,31 @@ class TestXafAuditfileExport(TransactionCase):
 
         self.assertTrue(record)
         self.assertTrue(record.name)
+        self.assertFalse(record.auditfile_success)
         # still contains the faulty auditfile for debugging purposes
+        self.assertTrue(record.auditfile)
+        self.assertTrue(record.auditfile_name)
+        self.assertTrue(record.company_id)
+        self.assertTrue(record.date_start)
+        self.assertTrue(record.date_end)
+        self.assertTrue(record.date_generated)
+        self.assertTrue(record.fiscalyear_name)
+
+    @mute_logger(
+        'odoo.addons.l10n_nl_xaf_auditfile_export.models.xaf_auditfile_export'
+    )
+    def test_04_invalid_characters(self):
+        ''' Error because of invalid characters in an auditfile '''
+        record = self.env['xaf.auditfile.export'].with_context(
+            dont_sanitize_xml=True
+        ).create({})
+        # add an invalid character
+        record.company_id.name += unichr(0x0B)
+        record.button_generate()
+
+        self.assertTrue(record)
+        self.assertTrue(record.name)
+        self.assertFalse(record.auditfile_success)
         self.assertTrue(record.auditfile)
         self.assertTrue(record.auditfile_name)
         self.assertTrue(record.company_id)

--- a/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
@@ -56,7 +56,8 @@ class TestXafAuditfileExport(TransactionCase):
 
         self.assertTrue(record)
         self.assertTrue(record.name)
-        self.assertFalse(record.auditfile)
+        # still contains the faulty auditfile for debugging purposes
+        self.assertTrue(record.auditfile)
         self.assertTrue(record.auditfile_name)
         self.assertTrue(record.company_id)
         self.assertTrue(record.date_start)


### PR DESCRIPTION
XML has some [invalid or discouraged characters](https://stackoverflow.com/questions/1707890/fast-way-to-filter-illegal-xml-unicode-chars-in-python) that the XML validation step fails on. This MR addresses several things:

1. Fix: in case the generated XAF file contains one of these characters (from an Odoo record), it replaces them with a space
2. Usability improvement: In case the XAF generation fails, besides the error, the traceback is also logged in the Odoo logfile
3. Usability improvement: In case the XML validation fails, the auditfile is still saved on the record, so that the user may download it and inspect the line at which the error occurred, and fix his source data. Now he sees a line number with a problem, but can't inspect the actual file to deduce which record caused it.
4. Speed improvement: the method of parsing the XML in order to validate it, resulted in very slow validation for bigger files (more than 5 minutes). Calling `xsd.assertValid` makes the validation, and thus the whole auditfile generation process, much faster (less than 1 minute). [Docs for this here.](https://lxml.de/validation.html#xmlschema)