### PR TITLE
[10.0][FIX] l10n_nl_tax_invoice_basis tests

### DIFF
--- a/l10n_nl_tax_invoice_basis/tests/test_tax_invoice_basis.py
+++ b/l10n_nl_tax_invoice_basis/tests/test_tax_invoice_basis.py
@@ -28,7 +28,7 @@ class TestTaxInvoiceBasis(TransactionCase):
             'account_id': receivable_account_id,
             'date_invoice': '2017-08-18',
             'date': '2017-07-01',
-            'type': 'in_invoice',
+            'type': 'out_refund',
         })
         invoice_line_account_id = self.env['account.account'].search(
             [('user_type_id', '=', self.env.ref(


### PR DESCRIPTION
Apparently these started breaking since [this update on account_tax_balance](https://github.com/OCA/account-financial-reporting/commit/50c389ea444cf31db99f035434f9a361f05548a7), the definition of a refund invoice changed, and the tests should follow suit.