### PR TITLE
[16.0] Repo Updated from template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.11.0
+_commit: v1.11.1
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP
@@ -9,12 +9,12 @@ github_enable_codecov: true
 github_enable_makepot: true
 github_enable_stale_action: true
 github_enforce_dev_status_compatibility: true
-include_wkhtmltopdf: false
+include_wkhtmltopdf: true
 odoo_version: 16.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
 rebel_module_groups: []
-repo_description: 'TODO: add repo description.'
+repo_description: Odoo Dutch Localization
 repo_name: l10n-netherlands
 repo_slug: l10n-netherlands
 repo_website: https://github.com/OCA/l10n-netherlands

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.5
+    rev: 3.1.8
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements
@@ -113,7 +113,7 @@ repos:
           - requirements.txt
           - --header
           - "# generated from manifests external_dependencies"
-  - repo: https://gitlab.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # l10n-netherlands
 
-TODO: add repo description.
+Odoo Dutch Localization
 
 <!-- /!\ do not modify below this line -->
 


### PR DESCRIPTION
Did a copier update according to https://github.com/OCA/oca-addons-repo-template

This should fix broken github actions