### PR TITLE
[13.0][FIX] l10n_nl_location_nuts: mocked tests

### DIFF
--- a/l10n_nl_location_nuts/__manifest__.py
+++ b/l10n_nl_location_nuts/__manifest__.py
@@ -10,6 +10,7 @@
     "author": "Onestein, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["base_location_nuts"],
+    "external_dependencies": {"python": ["vcrpy"]},
     "post_init_hook": "post_init_hook",
     "installable": True,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # generated from manifests external_dependencies
 python-stdnum
+vcrpy


### PR DESCRIPTION
Apparantly even external dependencies which are only used for tests, needs to be listed as external dependencies. Otherwise tests will fail with the automatically generated requirements.txt