### PR TITLE
[14.0] xaf_auditfile_export: improved selection of undivided profit account

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -353,7 +353,7 @@ class XafAuditfileExport(models.Model):
             "and l.company_id = %s "
             "and l.parent_state = 'posted' "
             "and t.include_initial_balance = true "
-            "and t.id != %s"
+            "and t.id != %s "
             "group by a.id, a.code",
             (self.date_start, self.company_id.id, cye_type_id),
         )

--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -376,13 +376,13 @@ class XafAuditfileExport(models.Model):
 
     def _get_undistributed_profits(self):
         """Get amount of undistributed profits."""
-        cye_type_id = self.env.ref("account.data_unaffected_earnings").id
+        current_year_earnings_type = self.env.ref("account.data_unaffected_earnings")
         self.env.cr.execute(
             STATEMENT_UNDIVIDED_PROFIT_BALANCE,
             dict(
                 company_id=self.company_id.id,
                 date_start=self.date_start,
-                current_year_earnings_type=cye_type_id,
+                current_year_earnings_type=current_year_earnings_type.id,
             ),
         )
         row = self.env.cr.fetchone()
@@ -392,13 +392,13 @@ class XafAuditfileExport(models.Model):
 
     def _get_undistributed_profit_account(self):
         """Get the id and the code for the undistributed profit account."""
-        cye_type_id = self.env.ref("account.data_unaffected_earnings").id
+        current_year_earnings_type = self.env.ref("account.data_unaffected_earnings")
         self.env.cr.execute(
             STATEMENT_UNDIVIDED_PROFIT_ACCOUNT,
             dict(
                 company_id=self.company_id.id,
                 date_start=self.date_start,
-                current_year_earnings_type=cye_type_id,
+                current_year_earnings_type=current_year_earnings_type.id,
             ),
         )
         row = self.env.cr.fetchone()


### PR DESCRIPTION
Present code always selects the account with the maximum code, even when a specific account has been specified to book the undivided profit on.