### PR TITLE
[14.0][FIX] l10n_nl_xaf_auditfile_export: Fixed auditfile exports with no a…

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -258,8 +258,10 @@ class XafAuditfileExport(models.Model):
 
     def get_accounts(self):
         """return recordset of accounts"""
-        return self.env["account.account"].search(
-            [("company_id", "=", self.company_id.id)]
+        return (
+            self.env["account.account"]
+            .sudo()
+            .search([("company_id", "=", self.company_id.id)])
         )
 
     @api.model


### PR DESCRIPTION
…ccounts when another company is active.

So, when you generate an auditfile on a multi-company instance, and your active company is a different one than on the `xaf.auditfile.export` record that you are trying to export, it gets exported without any accounts (`generalLedger` tag is empty). This fixes that.