### PR TITLE
[14.0] l10n_nl_xaf_auditfile_export: Made l10n_nl_xaf_auditfile_exports multi-company.

### DIFF
--- a/l10n_nl_xaf_auditfile_export/__manifest__.py
+++ b/l10n_nl_xaf_auditfile_export/__manifest__.py
@@ -11,6 +11,7 @@
     "summary": "Export XAF auditfiles for Dutch tax authorities",
     "depends": ["account"],
     "data": [
+        "security/ir_rule.xml",
         "security/ir.model.access.csv",
         "views/xaf_auditfile_export.xml",
         "views/templates.xml",

--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -120,7 +120,11 @@ class XafAuditfileExport(models.Model):
         "Auditfile filename", compute="_compute_auditfile_name", store=True
     )
     date_generated = fields.Datetime("Date generated", readonly=True, copy=False)
-    company_id = fields.Many2one("res.company", required=True)
+    company_id = fields.Many2one(
+        "res.company",
+        readonly=True,
+        default=lambda self: self.env.company,
+    )
 
     unit4 = fields.Boolean(
         help="The Unit4 system expects a value for "

--- a/l10n_nl_xaf_auditfile_export/security/ir_rule.xml
+++ b/l10n_nl_xaf_auditfile_export/security/ir_rule.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record model="ir.rule" id="auditfile_company">
+        <field name="name">Auditfile export multi-company</field>
+        <field name="model_id" ref="model_xaf_auditfile_export" />
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+    </record>
+</odoo>

--- a/l10n_nl_xaf_auditfile_export/views/xaf_auditfile_export.xml
+++ b/l10n_nl_xaf_auditfile_export/views/xaf_auditfile_export.xml
@@ -33,7 +33,6 @@
                             />
                             <field
                                 name="company_id"
-                                attrs="{'readonly': [('auditfile', '!=', False)]}"
                                 groups="base.group_multi_company"
                             />
                         </group>


### PR DESCRIPTION
This is a continuation on https://github.com/OCA/l10n-netherlands/pull/390

That PR 'solved' the multi-company bug by using sudo, and therefore allowing all companies to see and export eachother's exports, which is undesirable.

What this PR does, is it makes company_id a readonly value that is automatically set to your active company, and then it adds a record rule to limit each auditfile export to the company it belongs to.