### PR TITLE
[16.0][FIX] l10n_nl_xaf_auditfile_export: parse EntityRef error

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
+++ b/l10n_nl_xaf_auditfile_export/models/ir_qweb.py
@@ -13,7 +13,8 @@ class IrQwebAuditfileStringWidget999(models.AbstractModel):
     @api.model
     def value_to_html(self, value, options):
         value = value[: self._max_length] if value else ""
-        return super().value_to_html(value, options)
+        res = super().value_to_html(value, options)
+        return str(res)  # From markup to string
 
 
 class IrQwebAuditfileStringWidget9(models.AbstractModel):


### PR DESCRIPTION
When an account has an "&" character in its name, the XAF auditfile export fails.

Here are 2 different errors I was able to reproduce:

- `b'xmlParseEntityRef: no name'` (probably the one described in https://github.com/OCA/l10n-netherlands/issues/397)
- `b"EntityRef: expecting ';'"`

Steps to reproduce:

- install any chart of account, in this example we use `l10n_nl`
- create and confirm an invoice
- create an Audifile export and verify that the xaf file is successfully generated
- modify the name of account `110000 Debiteuren` (that for sure is listed in the auditfile), for example name it: "Debiteuren & test"
- create a new Audifile export and verify that an error is raised this time

After some investigations, it seems that `value_to_html()` returns a markup instead of a string. This seems making the `etree.XMLParser()` unhappy in case of any "&" character present. Converting the markup to string solves the issue. Not sure if there's a better way to solve it.
