### PR TITLE
[16.0][FIX] *+xaf_auditfile_export: use correct company in name

### DIFF
--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -81,7 +81,7 @@ class XafAuditfileExport(models.Model):
     @api.model
     def default_get(self, fields_list):
         defaults = super().default_get(fields_list)
-        company = self.env.user.company_id
+        company = self.env.company
         fy_dates = company.compute_fiscalyear_dates(datetime.now())
         defaults.setdefault("date_start", fy_dates["date_from"])
         defaults.setdefault("date_end", fy_dates["date_to"])
@@ -96,7 +96,6 @@ class XafAuditfileExport(models.Model):
                     "current_datetime": datetime.now().strftime("%Y"),
                 },
             )
-
         return defaults
 
     @api.constrains("date_start", "date_end")


### PR DESCRIPTION
Currently the export record is created with the current company in the environment (self.env.company), but the default company for the user (self.env.user.company_id) is applied to the name generated. This can and will lead to mismatches.

This fix will consistently use self.env.company.

The same change was already merged in 14.0.