### PR TITLE
[16.0][FIX] l10n_nl_tax_statement: hide cash-basis when NL invoice-basis

### DIFF
--- a/l10n_nl_tax_statement/models/res_config_settings.py
+++ b/l10n_nl_tax_statement/models/res_config_settings.py
@@ -10,4 +10,5 @@ class ResConfigSettings(models.TransientModel):
     l10n_nl_tax_invoice_basis = fields.Boolean(
         string="NL Tax Invoice Basis",
         related="company_id.l10n_nl_tax_invoice_basis",
+        readonly=False,
     )

--- a/l10n_nl_tax_statement/views/res_config_settings.xml
+++ b/l10n_nl_tax_statement/views/res_config_settings.xml
@@ -29,6 +29,13 @@
                     </div>
                 </div>
             </div>
+            <xpath expr="//div[@id='tax_exigibility']" position="attributes">
+                <attribute name="attrs">
+                    {
+                        'invisible': [('l10n_nl_tax_invoice_basis', '=', True)]
+                    }
+                </attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Hide cash basis when NL invoice basis is True (on the settings).

CC @ThijsvOers