### PR TITLE
[16.0][IMP] l10n_nl_tax_statement_icp: format BTW code on reports

### DIFF
--- a/l10n_nl_tax_statement_icp/models/l10n_nl_vat_statement_icp_line.py
+++ b/l10n_nl_tax_statement_icp/models/l10n_nl_vat_statement_icp_line.py
@@ -22,6 +22,9 @@ class VatStatementIcpLine(models.Model):
         string="VAT",
         readonly=True,
     )
+    format_vat = fields.Char(
+        compute="_compute_format_vat",
+    )
     country_code = fields.Char(
         readonly=True,
     )
@@ -31,6 +34,14 @@ class VatStatementIcpLine(models.Model):
     format_amount_products = fields.Char(compute="_compute_icp_amount_format")
     amount_services = fields.Monetary(readonly=True)
     format_amount_services = fields.Char(compute="_compute_icp_amount_format")
+
+    @api.depends("vat", "country_code")
+    def _compute_format_vat(self):
+        for line in self:
+            if line.country_code and line.vat:
+                line.format_vat = line.vat.lstrip(line.country_code)
+            else:
+                line.format_vat = line.vat
 
     @api.depends("amount_products", "amount_services")
     def _compute_icp_amount_format(self):

--- a/l10n_nl_tax_statement_icp/report/l10n_nl_tax_statement_icp_xlsx.py
+++ b/l10n_nl_tax_statement_icp/report/l10n_nl_tax_statement_icp_xlsx.py
@@ -102,8 +102,8 @@ class NLTaxStatementIcpXlsx(models.AbstractModel):
         """Define the report columns used to generate report"""
         return {
             0: {"header": _("Partner"), "field": "partner_name", "width": 60},
-            1: {"header": _("VAT"), "field": "vat", "width": 50},
-            2: {"header": _("Country Code"), "field": "country_code", "width": 14},
+            1: {"header": _("Country Code"), "field": "country_code", "width": 14},
+            2: {"header": _("VAT"), "field": "format_vat", "width": 50},
             3: {"header": _("Currency"), "field": "currency_name", "width": 14},
             4: {"header": _("Amount Product"), "field": "amount_products", "width": 20},
             5: {"header": _("Amount Service"), "field": "amount_services", "width": 20},

--- a/l10n_nl_tax_statement_icp/report/report_tax_statement.xml
+++ b/l10n_nl_tax_statement_icp/report/report_tax_statement.xml
@@ -31,8 +31,8 @@
                         >
                             <div class="nl_tax_act_as_row labels">
                                 <div class="nl_tax_act_as_cell left">Partner</div>
-                                <div class="nl_tax_act_as_cell left">VAT</div>
                                 <div class="nl_tax_act_as_cell left">Country Code</div>
+                                <div class="nl_tax_act_as_cell left">VAT</div>
                                 <div class="nl_tax_act_as_cell right">Currency</div>
                                 <div
                                     class="nl_tax_act_as_cell right"
@@ -48,10 +48,10 @@
                                         <span t-field="line.partner_id" />
                                     </div>
                                     <div class="nl_tax_act_as_cell left">
-                                        <span t-field="line.vat" />
+                                        <span t-field="line.country_code" />
                                     </div>
                                     <div class="nl_tax_act_as_cell left">
-                                        <span t-field="line.country_code" />
+                                        <span t-field="line.format_vat" />
                                     </div>
                                     <div class="nl_tax_act_as_cell right">
                                         <span t-field="line.currency_id" />

--- a/l10n_nl_tax_statement_icp/tests/test_l10n_nl_tax_statement_icp.py
+++ b/l10n_nl_tax_statement_icp/tests/test_l10n_nl_tax_statement_icp.py
@@ -72,6 +72,7 @@ class TestTaxStatementIcp(TestVatStatement):
     def test_04_icp_invoice(self):
         self._create_test_invoice()
         self.invoice_1.partner_id.country_id = self.env.ref("base.be")
+        self.invoice_1.partner_id.vat = "BE0477472701"
         self.statement_1.post()
         self.statement_with_icp = self.env["l10n.nl.vat.statement"].create(
             {"name": "Statement 1"}
@@ -90,6 +91,11 @@ class TestTaxStatementIcp(TestVatStatement):
             self.assertEqual(float(amount_products), icp_line.amount_products)
             amount_services = icp_line.format_amount_services
             self.assertEqual(float(amount_services), icp_line.amount_services)
+            self.assertTrue(icp_line.vat)
+            self.assertTrue(icp_line.format_vat)
+
+        # Export XLS without errors
+        self._check_export_xls(self.statement_with_icp)
 
     def test_05_icp_invoice_service(self):
         self.tax_1.name = self.tax_1.name + " dienst"
@@ -117,6 +123,8 @@ class TestTaxStatementIcp(TestVatStatement):
             self.assertEqual(float(amount_products), icp_line.amount_products)
             amount_services = icp_line.format_amount_services
             self.assertEqual(float(amount_services), icp_line.amount_services)
+            self.assertFalse(icp_line.vat)
+            self.assertFalse(icp_line.format_vat)
 
         # Export XLS without errors
         self._check_export_xls(self.statement_with_icp)

--- a/l10n_nl_tax_statement_icp/views/l10n_nl_vat_statement_view.xml
+++ b/l10n_nl_tax_statement_icp/views/l10n_nl_vat_statement_view.xml
@@ -30,8 +30,8 @@
                     <field name="icp_line_ids">
                         <tree editable="bottom" create="false" delete="false">
                             <field name="partner_id" />
-                            <field name="vat" />
                             <field name="country_code" />
+                            <field name="format_vat" />
                             <field name="currency_id" />
                             <field name="amount_products" />
                             <field name="amount_services" />


### PR DESCRIPTION
The request for this change comes from an accountant.
It seems that other accounting software do not display the `Landcode` as prefix in the `BTW Nummer`.

Here is just one of the examples:

![image](https://github.com/OCA/l10n-netherlands/assets/7657635/d4e75944-c7b9-4a96-97b7-a43d9059d4d0)

So with this PR, we make the ICP reports resembling the other accounting software.