### PR TITLE
[FIX] l10n_nl_kvk: adapt tsts to changed demo data

### DIFF
--- a/l10n_nl_kvk/tests/test_l10n_nl_kvk.py
+++ b/l10n_nl_kvk/tests/test_l10n_nl_kvk.py
@@ -345,13 +345,19 @@ class TestNLKvK(TransactionCase):
             self.assertIn(entity_type, ['legal_person', 'headquarters'])
             self.assertEqual(test_line.name, '68727720')
             self.assertEqual(test_line.kvk, '68727720')
-            self.assertEqual(test_line.partner_name, 'Test NV Katrien')
             if entity_type == 'legal_person':
                 self.assertFalse(test_line.partner_city)
+                self.assertEqual(
+                    test_line.partner_name, 'Test NV Katrien - Statutory Naam')
             else:
                 self.assertEqual(test_line.partner_city, 'Veendam')
+                self.assertEqual(
+                    test_line.partner_name, 'Test NV Katrien - Handelsnaam')
             test_line.set_partner_fields()
-            self.assertEqual(my_partner.name, 'Test NV Katrien')
+            if entity_type == 'legal_person':
+                self.assertEqual(my_partner.name, 'Test NV Katrien - Statutory Naam')
+            else:
+                self.assertEqual(my_partner.name, 'Test NV Katrien - Handelsnaam')
             self.assertFalse(my_partner.vat)
             self.assertEqual(my_partner.country_id, nl_country)
             if entity_type == 'legal_person':
@@ -377,8 +383,8 @@ class TestNLKvK(TransactionCase):
         self.assertFalse(wizard_action)
 
         # partner fields directly set (without popup)
-        self.assertEqual(my_partner.name, 'Local Funzoom N.V.')
-        self.assertEqual(my_partner.city, 'Leiderdorp')
+        self.assertEqual(my_partner.name, 'Local Funzoom N.V. - Statutory Naam')
+        self.assertEqual(my_partner.city, 'Denekamp')
         self.assertFalse(my_partner.vat)
         self.assertEqual(my_partner.country_id, nl_country)
 


### PR DESCRIPTION
turns out the tests call KVK's test environment, and the test environment has changed the values being returned slightly.

Verify with

```
curl -X 'GET' 'https://developers.kvk.nl/test/api/v1/zoeken?kvkNummer=68727720&pagina=1&aantal=10' -H 'accept: application/hal+json'

curl -X 'GET' 'https://developers.kvk.nl/test/api/v1/zoeken?kvkNummer=90004760&pagina=1&aantal=10' -H 'accept: application/hal+json'
```

Now the right thing to do would be to mock.patch away those calls of course, but as of https://developers.kvk.nl/nl/documentation/testing the v1 api this addon uses will be retired by July 29th, so I'd find it a little bit pointless to do so now. By that date we should deactivate this addon anyways if nobody ports it to the v2 api meanwhile.