### PR TITLE
[12.0][ADD] l10n_nl_tax_statement: add chatter

### DIFF
--- a/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
+++ b/l10n_nl_tax_statement/models/l10n_nl_vat_statement.py
@@ -10,6 +10,7 @@ from odoo.tools.misc import formatLang
 
 
 class VatStatement(models.Model):
+    _inherit = ['mail.thread']
     _name = 'l10n.nl.vat.statement'
     _description = 'Netherlands Vat Statement'
 

--- a/l10n_nl_tax_statement/views/l10n_nl_vat_statement_view.xml
+++ b/l10n_nl_tax_statement/views/l10n_nl_vat_statement_view.xml
@@ -109,6 +109,10 @@
                         </page>
                     </notebook>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
this is practical to attach the PDFs you produce when submitting your statement directly to the Odoo record