### PR TITLE
[16.0][FIX] ..partner_name: use sudo() to read config

### DIFF
--- a/l10n_nl_partner_name/models/res_partner.py
+++ b/l10n_nl_partner_name/models/res_partner.py
@@ -69,6 +69,7 @@ class ResPartner(models.Model):
             map(
                 str.strip,
                 self.env["ir.config_parameter"]
+                .sudo()
                 .get_param(
                     "l10n_nl_partner_name_infixes", "van,der,den,op,ter,de,v/d,d','t,te"
                 )


### PR DESCRIPTION
Newer versions of Odoo restricted direct access to ir.config_parameter.

Changing contacts can now lead to access errors.