### PR TITLE
[FIX] test-requirements: allow installation of l10n_nl on runboat

### DIFF
--- a/test-requirements
+++ b/test-requirements
@@ -1,0 +1,1 @@
+phonenumbers


### PR DESCRIPTION
Fixes
```
Unable to install module "account_peppol" because an external dependency is
not met.
```