### PR TITLE
[18.0][FIX] l10n_nl_xaf_auditfile_export: replace full_reconcile_id.name

### DIFF
--- a/l10n_nl_xaf_auditfile_export/views/templates.xml
+++ b/l10n_nl_xaf_auditfile_export/views/templates.xml
@@ -261,7 +261,7 @@
                         <amnt><t t-esc="abs(round(l.balance,2))" /></amnt>
                         <amntTp><t t-esc="'C' if l.credit else 'D'" /></amntTp>
                         <recRef t-if="l.full_reconcile_id"><t
-                                        t-esc="l.full_reconcile_id.name"
+                                        t-esc="l.full_reconcile_id.id"
                                     /></recRef>
                         <custSupID t-if="l.partner_id"><t
                                         t-esc="l.partner_id.id"


### PR DESCRIPTION
In Odoo 17.0 and 18.0 the "account.full.reconcile" field "name" was removed:
https://github.com/odoo/odoo/commit/30a37c10ec8115b8c7b84f908a5fb4871d2f6cfb

This PR fixes the following error:
```
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
AttributeError: 'account.full.reconcile' object has no attribute 'name'
Template: l10n_nl_xaf_auditfile_export.auditfile_template
Path: /t/*/*[2]/*[11]/*[4]/*[4]/*[6]/*[8]/*
Node: <ns0:t xmlns:ns0="http://www.auditfiles.nl/XAF/3.2" t-esc="l.full_reconcile_id.name"/>
```
