### PR TITLE
[17.0][FIX] l10n_nl_xaf_auditfile_export: replace full_reconcile_id.name

### DIFF
--- a/l10n_nl_xaf_auditfile_export/views/templates.xml
+++ b/l10n_nl_xaf_auditfile_export/views/templates.xml
@@ -258,7 +258,7 @@
                         <amnt><t t-esc="abs(round(l.balance,2))" /></amnt>
                         <amntTp><t t-esc="'C' if l.credit else 'D'" /></amntTp>
                         <recRef t-if="l.full_reconcile_id"><t
-                                        t-esc="l.full_reconcile_id.name"
+                                        t-esc="l.full_reconcile_id.id"
                                     /></recRef>
                         <custSupID t-if="l.partner_id"><t
                                         t-esc="l.partner_id.id"


### PR DESCRIPTION
Backport of https://github.com/OCA/l10n-netherlands/pull/441 to V17