### PR TITLE
[16.0][IMP] l10n_nl_xaf_auditfile_export: reduce memory footprint

### DIFF
--- a/l10n_nl_xaf_auditfile_export/README.rst
+++ b/l10n_nl_xaf_auditfile_export/README.rst
@@ -39,6 +39,13 @@ An option allows to export the XAF audit files in a format that is accepted by U
 .. contents::
    :local:
 
+Installation
+============
+
+In order to reduce the memory footprint of the validation step, you can install the xmllint tool, which is part of the `libxml2 <https://gitlab.gnome.org/GNOME/libxml2>`_ package:
+
+    sudo apt install libxml2-utils
+
 Configuration
 =============
 

--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -111,7 +111,7 @@ class XafAuditfileExport(models.Model):
         "If you want to export an auditfile with the official standard "
         "(missing the Unit4 compatibility) just set this flag to False."
     )
-    auditfile_success = fields.Boolean(copy=False)
+    auditfile_success = fields.Boolean(copy=False, readonly=True)
     date_generated = fields.Datetime("Date generated", readonly=True, copy=False)
     company_id = fields.Many2one("res.company", "Company", required=True)
 

--- a/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/models/xaf_auditfile_export.py
@@ -1,17 +1,15 @@
 # Copyright 2015 Therp BV <https://therp.nl>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-import base64
 import collections
 import logging
 import os
 import shutil
+import subprocess
 import sys
 import time
 import traceback
-import zipfile
 from datetime import datetime, timedelta
-from io import BytesIO
 from tempfile import mkdtemp
 
 import psutil
@@ -82,9 +80,8 @@ class XafAuditfileExport(models.Model):
         for item in self:
             item.auditfile_name = "%s.xaf" % item.name
             if item.auditfile:
-                auditfile = base64.b64decode(item.auditfile)
-                zf = BytesIO(auditfile)
-                if zipfile.is_zipfile(zf):
+                attachment = item._get_auditfile_attachment(create=False)
+                if (attachment.mimetype or "").endswith("zip"):
                     item.auditfile_name += ".zip"
 
     def _compute_fiscalyear_name(self):
@@ -98,7 +95,7 @@ class XafAuditfileExport(models.Model):
     fiscalyear_name = fields.Char(compute="_compute_fiscalyear_name")
     auditfile = fields.Binary(readonly=True, copy=False)
     auditfile_name = fields.Char(
-        "Auditfile filename", compute="_compute_auditfile_name", store=True
+        "Auditfile filename", compute="_compute_auditfile_name"
     )
     date_generated = fields.Datetime(readonly=True, copy=False)
     company_id = fields.Many2one("res.company", required=True)
@@ -150,28 +147,49 @@ class XafAuditfileExport(models.Model):
         """return the qweb template to be rendered"""
         return "l10n_nl_xaf_auditfile_export.auditfile_template"
 
+    @api.model
+    def _render_qweb_iterator(self, template, values=None, **options):
+        """
+        This is a near-copy of ir.qweb#_render up until joining the generated fragments
+        to one big string.
+        """
+        irQweb = (
+            self.env["ir.qweb"].with_context(**options)._prepare_environment(values)
+        )
+        template_functions, def_name = irQweb._compile(template)
+        render_template = template_functions[def_name]
+        return render_template(irQweb, values)
+
+    def _get_auditfile_attachment(self, create=True):
+        self.ensure_one()
+        IrAttachment = self.env["ir.attachment"]
+        return IrAttachment.search(
+            [
+                ("res_model", "=", self._name),
+                ("res_id", "=", self.id),
+                ("res_field", "=", "auditfile"),
+            ]
+        ) or (
+            create
+            and IrAttachment.create(
+                {
+                    "name": "auditfile",
+                    "res_model": self._name,
+                    "res_id": self.id,
+                    "res_field": "auditfile",
+                }
+            )
+            or IrAttachment
+        )
+
     def button_generate(self):
         t0 = time.time()
         m0 = memory_info()
         self.date_generated = fields.Datetime.now()
         auditfile_template = self._get_auditfile_template()
-        xml = self.env["ir.qweb"]._render(
+        xml_iterator = self._render_qweb_iterator(
             auditfile_template, {"self": self}, minimal_qcontext=True
         )
-        # convert to string and prepend XML encoding declaration
-        xml = (
-            str(xml)
-            .strip()
-            .replace(
-                "<auditfile ",
-                '<?xml version="1.0" encoding="UTF-8"?>\n<auditfile ',
-                1,
-            )
-        )
-        # removes invalid characters from xml
-        if not self.env.context.get("dont_sanitize_xml"):
-            xml = xml.translate(UNICODE_SANITIZE_TRANSLATION)
-
         filename = self.name + ".xaf"
         filename = filename.replace(os.sep, " ")
         tmpdir = mkdtemp()
@@ -181,8 +199,16 @@ class XafAuditfileExport(models.Model):
         self.auditfile_success = False
         try:
             with open(auditfile, "w+") as tmphandle:
-                tmphandle.write(xml)
-            del xml
+                # prepend XML encoding declaration
+                tmphandle.write('<?xml version="1.0" encoding="UTF-8"?>')
+                # remove invalid characters from xml if not asked not to
+                sanitize = not self.env.context.get("dont_sanitize_xml")
+                for fragment in xml_iterator:
+                    tmphandle.write(
+                        fragment.translate(UNICODE_SANITIZE_TRANSLATION)
+                        if sanitize
+                        else fragment
+                    )
 
             logging.getLogger(__name__).debug(
                 "Created an auditfile in %ss, using %sk memory",
@@ -192,32 +218,67 @@ class XafAuditfileExport(models.Model):
 
             # Store in compressed format on the auditfile record
             zip_path = shutil.make_archive(archive, "zip", tmpdir, verbose=True)
-            with open(zip_path, "rb") as auditfile_zip:
-                self.auditfile = base64.b64encode(auditfile_zip.read())
+            attachment = self._get_auditfile_attachment()
+            attachment.write(
+                {
+                    "raw": open(zip_path, "rb").read(),
+                    "mimetype": "application/zip",
+                }
+            )
+            self.invalidate_recordset(["auditfile"])
             logging.getLogger(__name__).debug(
-                "Created an auditfile in %ss, using %sk memory",
+                "Created an auditfile archive in %ss, using %sk memory",
                 int(time.time() - t0),
                 (memory_info() - m0) / 1024,
             )
 
             # Validate the generated XML
-            xsd = etree.XMLSchema(
-                etree.parse(
-                    open(
-                        modules.get_resource_path(
-                            "l10n_nl_xaf_auditfile_export",
-                            "data",
-                            "XmlAuditfileFinancieel3.2.xsd",
-                        )
-                    )
-                )
+            schema_file = modules.get_resource_path(
+                "l10n_nl_xaf_auditfile_export",
+                "data",
+                "XmlAuditfileFinancieel3.2.xsd",
             )
-            xsd.assertValid(etree.parse(auditfile))
-            del xsd
+            xmllint = shutil.which("xmllint")
+            if xmllint:
+                subprocess.run(
+                    [
+                        xmllint,
+                        "--noout",
+                        "--stream",
+                        "--schema",
+                        schema_file,
+                        auditfile,
+                    ],
+                    capture_output=True,
+                    check=True,
+                )
+                logging.getLogger(__name__).debug(
+                    "schema validation done with %sk memory",
+                    (memory_info() - m0) / 1024,
+                )
+            else:
+                logging.getLogger(__name__).info(
+                    "using built in xml schema validation. "
+                    "if you run into out of memory issues, install xmllint"
+                )
+                xsd = etree.XMLSchema(etree.parse(open(schema_file)))
+                for event, element in etree.iterparse(
+                    open(auditfile, "rb"), schema=xsd
+                ):
+                    del event
+                    del element
+                logging.getLogger(__name__).debug(
+                    "schema validation (iter) done with %sk memory",
+                    (memory_info() - m0) / 1024,
+                )
 
             self.auditfile_success = True
 
-        except (etree.XMLSyntaxError, etree.DocumentInvalid) as e:
+        except (
+            etree.XMLSyntaxError,
+            etree.DocumentInvalid,
+            subprocess.CalledProcessError,
+        ) as e:
             logging.getLogger(__name__).error(e)
             logging.getLogger(__name__).info(traceback.format_exc())
             self.message_post(body=e)
@@ -396,10 +457,13 @@ class XafAuditfileExport(models.Model):
             .ids
         )
         self.env["account.move"].invalidate_model()
+        # the template accesses account.move#line_ids so it's crucial to reset those too
+        self.env["account.move.line"].invalidate_model()
         for chunk in chunks(move_ids):
             for move in self.env["account.move"].browse(chunk):
                 yield move
             self.env["account.move"].invalidate_model()
+            self.env["account.move.line"].invalidate_model()
 
     @api.model
     def get_move_period_number(self, move):

--- a/l10n_nl_xaf_auditfile_export/readme/INSTALL.rst
+++ b/l10n_nl_xaf_auditfile_export/readme/INSTALL.rst
@@ -1,0 +1,3 @@
+In order to reduce the memory footprint of the validation step, you can install the xmllint tool, which is part of the `libxml2 <https://gitlab.gnome.org/GNOME/libxml2>`_ package:
+
+    sudo apt install libxml2-utils

--- a/l10n_nl_xaf_auditfile_export/readme/newsfragments/445.feature
+++ b/l10n_nl_xaf_auditfile_export/readme/newsfragments/445.feature
@@ -1,0 +1,1 @@
+reduce memory footprint. Can be even more reduced by installing xmllint

--- a/l10n_nl_xaf_auditfile_export/static/description/index.html
+++ b/l10n_nl_xaf_auditfile_export/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -375,24 +376,31 @@ ul.auto-toc {
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
-<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-8">Other credits</a><ul>
-<li><a class="reference internal" href="#icon" id="toc-entry-9">Icon</a></li>
+<li><a class="reference internal" href="#installation" id="toc-entry-1">Installation</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-2">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-3">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-4">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-5">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-6">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-7">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-8">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-9">Other credits</a><ul>
+<li><a class="reference internal" href="#icon" id="toc-entry-10">Icon</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-10">Maintainers</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-11">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="installation">
+<h1><a class="toc-backref" href="#toc-entry-1">Installation</a></h1>
+<p>In order to reduce the memory footprint of the validation step, you can install the xmllint tool, which is part of the <a class="reference external" href="https://gitlab.gnome.org/GNOME/libxml2">libxml2</a> package:</p>
+<blockquote>
+sudo apt install libxml2-utils</blockquote>
+</div>
 <div class="section" id="configuration">
-<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Configuration</a></h1>
 <p>The exporting feature is available to the users who have <cite>Billing Administrator</cite> or <cite>Accountant</cite> rights for accounting.</p>
 <p>To configure the default start and end dates of the actual fiscal year, go to <cite>accounting</cite>/<cite>settings</cite> and change the
 Last Day of the year you want to export. Then in the form of the audit file export, by default the end-date will be set
@@ -401,7 +409,7 @@ Be aware that in case the OCA module <cite>account_fiscal_year</cite> is install
 overridden, taking by default the date range defined for the actual fiscal year (check <cite>Settings</cite>/<cite>Date Ranges</cite>).</p>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Usage</a></h1>
 <p>To use this module, you need to:</p>
 <ul class="simple">
 <li>be sure that you have <cite>Billing Administrator</cite> or <cite>Accountant</cite> rights for accounting</li>
@@ -412,13 +420,13 @@ overridden, taking by default the date range defined for the actual fiscal year 
 </ul>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>encrypted files would be nice</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-netherlands/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -426,15 +434,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-6">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Authors</a></h2>
 <ul class="simple">
 <li>Therp BV</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Contributors</a></h2>
 <ul class="simple">
 <li>Holger Brunn &lt;<a class="reference external" href="mailto:hbrunn&#64;therp.nl">hbrunn&#64;therp.nl</a>&gt;</li>
 <li>Andrea Stirpe &lt;<a class="reference external" href="mailto:a.stirpe&#64;onestein.nl">a.stirpe&#64;onestein.nl</a>&gt;</li>
@@ -443,16 +451,18 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h2><a class="toc-backref" href="#toc-entry-8">Other credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-9">Other credits</a></h2>
 <div class="section" id="icon">
-<h3><a class="toc-backref" href="#toc-entry-9">Icon</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-10">Icon</a></h3>
 <p><a class="reference external" href="https://openclipart.org/detail/180891">https://openclipart.org/detail/180891</a></p>
 </div>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-11">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
+++ b/l10n_nl_xaf_auditfile_export/tests/test_l10n_nl_xaf_auditfile_export.py
@@ -3,8 +3,10 @@
 
 import base64
 import os
+import subprocess
 from datetime import timedelta
 from io import BytesIO
+from unittest import mock
 from zipfile import ZipFile
 
 from lxml import etree
@@ -113,7 +115,9 @@ class TestXafAuditfileExport(TransactionCase):
         with ZipFile(zf, "r") as archive:
             filelist = archive.filelist
             contents = archive.read(filelist[-1]).decode()
-        self.assertTrue(contents.startswith("<?xml "))
+        self.assertTrue(
+            contents.startswith('<?xml version="1.0" encoding="UTF-8"?>\n<auditfile ')
+        )
 
     @mute_logger("odoo.addons.l10n_nl_xaf_auditfile_export.models.xaf_auditfile_export")
     def test_03_export_error(self):
@@ -157,7 +161,11 @@ class TestXafAuditfileExport(TransactionCase):
             with ZipFile(zf, "r") as archive:
                 filelist = archive.filelist
                 contents = archive.read(filelist[-1]).decode()
-            self.assertTrue(contents.startswith("<?xml "))
+            self.assertTrue(
+                contents.startswith(
+                    '<?xml version="1.0" encoding="UTF-8"?>\n<auditfile '
+                )
+            )
 
     def test_05_export_success(self):
         """Export auditfile with / character in filename"""
@@ -334,3 +342,13 @@ class TestXafAuditfileExport(TransactionCase):
         record.company_id.name += " & OCA"
         record.button_generate()
         self.assertTrue(record.auditfile_success)
+
+    def test_11_xmllint(self):
+        """
+        Test behavior with xmllint available
+        """
+        with mock.patch("shutil.which") as which, mock.patch("subprocess.run") as run:
+            which.return_value = "/mock/xmllint"
+            self.test_02_export_success()
+            run.side_effect = subprocess.CalledProcessError(-1, "xmllint")
+            self.test_03_export_error()


### PR DESCRIPTION
this keeps memory usage for generating the auditfile constant by not having the xml fully loaded in memory. when having xmllint installed, the xml file is never fully loaded at all.

the zipped version then is the upper bound for memory usage, but thankfully xml compresses pretty well.

while being on it I made the auditfile_success flag readonly because users have no business changing that.

should migrate quite straightforwardly to higher versions